### PR TITLE
PR: Add a file switcher instance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ Jupyter notebook integration with Spyder.
 from setuptools import find_packages, setup
 from spyder_notebook import __version__
 
-REQUIREMENTS = ['spyder>=3', 'notebook>=4.3']
+REQUIREMENTS = ['spyder>=3.1.4', 'notebook>=4.3']
 
 setup(
     name='spyder-notebook',

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -296,7 +296,7 @@ class NotebookPlugin(SpyderPluginWidget):
         if not self.tabwidget.count():
             return
         if self.fileswitcher_dlg is not None and \
-            self.fileswitcher_dlg.is_visible:
+           self.fileswitcher_dlg.is_visible:
             self.fileswitcher_dlg.hide()
             self.fileswitcher_dlg.is_visible = False
             return

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -60,33 +60,39 @@ def test_fileswitcher(qtbot):
     """Test the fileswithcher."""
     # Create notebook
     notebook = setup_notebook(qtbot)
+
     # Create new notebook
     notebook.create_new_client()
-    
+
     # Wait for prompt
     nbwidget = notebook.get_current_nbwidget()
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Assert that we have two notebooks
     assert len(notebook.clients) == 2
-    
+
     # Fileswitcher of the notebook
     notebook.open_fileswitcher_dlg()
     fileswitcher = notebook.fileswitcher_dlg
-    
+
     # Search for the first untitled0 notebook
     fileswitcher.edit.setText("0")
-    qtbot.keyClick(fileswitcher, Qt.Key_Enter)
     
     # Assert that we are at the first notebook
     assert notebook.tabwidget.currentIndex() == 0
-    
+    assert notebook.get_current_client().get_short_name() == 'untitled0.ipynb'
+
     # Search for the untitled1 notebook
     fileswitcher.edit.setText("1")
-    qtbot.keyClick(fileswitcher, Qt.Key_Enter)
-    
+
     # Assert that we are at the first notebook
     assert notebook.tabwidget.currentIndex() == 1
+    assert notebook.get_current_client().get_short_name() == 'untitled1.ipynb'
+
+    # Assert that the fileswitcher dialog hides
+    qtbot.keyPress(fileswitcher.edit, Qt.Key_Enter)
+    qtbot.waitUntil(lambda: not fileswitcher.isVisible(), timeout=NOTEBOOK_UP)
+    assert not fileswitcher.isVisible()
 
 
 if __name__ == "__main__":

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -9,6 +9,7 @@
 # Test library imports
 import pytest
 from qtpy.QtWebEngineWidgets import WEBENGINE
+from qtpy.QtCore import Qt
 
 # Local imports
 from spyder_notebook.notebookplugin import NotebookPlugin
@@ -53,6 +54,39 @@ def test_new_notebook(qtbot):
 
     # Assert that we have one notebook
     assert len(notebook.clients) == 1
+
+
+def test_fileswitcher(qtbot):
+    """Test the fileswithcher."""
+    # Create notebook
+    notebook = setup_notebook(qtbot)
+    # Create new notebook
+    notebook.create_new_client()
+    
+    # Wait for prompt
+    nbwidget = notebook.get_current_nbwidget()
+    qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
+
+    # Assert that we have two notebooks
+    assert len(notebook.clients) == 2
+    
+    # Fileswitcher of the notebook
+    notebook.open_fileswitcher_dlg()
+    fileswitcher = notebook.fileswitcher_dlg
+    
+    # Search for the first untitled0 notebook
+    fileswitcher.edit.setText("0")
+    qtbot.keyClick(fileswitcher, Qt.Key_Enter)
+    
+    # Assert that we are at the first notebook
+    assert notebook.tabwidget.currentIndex() == 0
+    
+    # Search for the untitled1 notebook
+    fileswitcher.edit.setText("1")
+    qtbot.keyClick(fileswitcher, Qt.Key_Enter)
+    
+    # Assert that we are at the first notebook
+    assert notebook.tabwidget.currentIndex() == 1
 
 
 if __name__ == "__main__":

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -113,13 +113,13 @@ class NotebookClient(QWidget):
     render notebooks.
     """
 
-    def __init__(self, plugin, name):
+    def __init__(self, plugin, filename):
         """Constructor."""
         super(NotebookClient, self).__init__(plugin)
 
         if os.name == 'nt':
-            name = name.replace('/','\\')
-        self.filename = name
+            filename = filename.replace('/', '\\')
+        self.filename = filename
 
         self.file_url = None
         self.server_url = None
@@ -178,8 +178,8 @@ class NotebookClient(QWidget):
         """Load the associated notebook."""
         self.go_to(self.file_url)
 
-    def get_name(self):
-        """Get notebook's name."""
+    def get_filename(self):
+        """Get notebook's filename."""
         return self.filename
 
     def get_short_name(self):

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -115,6 +115,8 @@ class NotebookClient(QWidget):
     def __init__(self, plugin, name):
         super(NotebookClient, self).__init__(plugin)
 
+        if os.name == 'nt':
+            name = name.replace('/','\\')
         self.filename = name
 
         self.file_url = None

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -116,7 +116,7 @@ class NotebookClient(QWidget):
     def __init__(self, plugin, name):
         super(NotebookClient, self).__init__(plugin)
 
-        self.name = name
+        self.filename = name
 
         self.file_url = None
         self.server_url = None
@@ -139,7 +139,7 @@ class NotebookClient(QWidget):
     def register(self, server_info):
         """Register attributes that can be computed with the server info."""
         # Path relative to the server directory
-        self.path = os.path.relpath(self.name,
+        self.path = os.path.relpath(self.filename,
                                     start=server_info['notebook_dir'])
 
         # Full url used to render the notebook as a web page
@@ -162,11 +162,11 @@ class NotebookClient(QWidget):
         self.go_to(self.file_url)
 
     def get_name(self):
-        return self.name
+        return self.filename
 
     def get_short_name(self):
         """Get a short name for the notebook."""
-        sname = osp.basename(self.name)
+        sname = osp.basename(self.filename)
         if len(sname) > 15:
             sname = sname[:15]
         return sname


### PR DESCRIPTION
Fixes #45 

Preview:

![fs](https://cloud.githubusercontent.com/assets/16781833/24132805/2522bee2-0dc6-11e7-961d-609b6858499e.png)
___________________________________________

In order for this to work there is a need to modify the FileSwitcher class in spyder to map the correct methods to get the current widget (client).

The methods to change will be:
* `get_editor` (change the call for the `get_current_editor`)
* `save_initial_state` (let the current widget not have `textCursor`)

Also this works for now by adding a button to open the fileswitcher.