### PR TITLE
PR: Move version out of init file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,34 @@ Spyder notebook plugin
 Jupyter notebook integration with Spyder.
 """
 
+# Standard library imports
+import ast
+import os
+
 # Third party imports
 from setuptools import find_packages, setup
-from spyder_notebook import __version__
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version(module='spyder_notebook'):
+    """Get version."""
+    with open(os.path.join(HERE, module, '_version.py'), 'r') as f:
+        data = f.read()
+    lines = data.split('\n')
+    for line in lines:
+        if line.startswith('VERSION_INFO'):
+            version_tuple = ast.literal_eval(line.split('=')[-1].strip())
+            version = '.'.join(map(str, version_tuple))
+            break
+    return version
+
 
 REQUIREMENTS = ['spyder>=3', 'notebook>=4.3']
 
 setup(
     name='spyder-notebook',
-    version=__version__,
+    version=get_version(),
     keywords='spyder jupyter notebook',
     url='https://github.com/spyder-ide/spyder-notebook',
     license='MIT',

--- a/spyder_notebook/__init__.py
+++ b/spyder_notebook/__init__.py
@@ -9,8 +9,6 @@
 
 # Local imports
 from spyder_notebook.notebookplugin import NotebookPlugin as PLUGIN_CLASS
-
-VERSION_INFO = (0, 1, 0, 'dev0')
-__version__ = '.'.join(map(str, VERSION_INFO))
+from spyder_notebook._version import __version__
 
 PLUGIN_CLASS

--- a/spyder_notebook/_version.py
+++ b/spyder_notebook/_version.py
@@ -1,2 +1,3 @@
+"""Version File."""
 VERSION_INFO = (0, 1, 0, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder_notebook/_version.py
+++ b/spyder_notebook/_version.py
@@ -1,0 +1,2 @@
+VERSION_INFO = (0, 1, 0, 'dev0')
+__version__ = '.'.join(map(str, VERSION_INFO))


### PR DESCRIPTION
Fixes #54

@ccordoba12 I move `__version__` to `_version.py` as you suggested

But that wasn't enough, when doing: `from spyder_notebook._version import __version__` the module is imported and the `__init__.py` is exectuted anyway

I copied a modified `get_version()` function from other spyder plugins, is that ok?

