### PR TITLE
PR: More robust parsing of server reply in NotebookClient.get_kernel_id()

### DIFF
--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -34,7 +34,7 @@ popd
 conda install -y notebook
 
 # Install testing dependencies
-conda install -y pytest pytest-cov flaky
+conda install -y pytest pytest-cov pytest-mock flaky
 pip install coveralls pytest-qt
 
 # List packages for debugging

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -227,7 +227,8 @@ class NotebookClient(QWidget):
             path = self.path
 
         for session in sessions:
-            if session['notebook']['path'] == path:
+            notebook_path = session.get('notebook', {}).get('path')
+            if notebook_path is not None and notebook_path == path:
                 kernel_id = session['kernel']['id']
                 return kernel_id
 

--- a/spyder_notebook/widgets/tests/test_client.py
+++ b/spyder_notebook/widgets/tests/test_client.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""Tests for client.py covering NotebookClient."""
+
+# Third-party imports
+from qtpy.QtWidgets import QWidget
+
+# Local imports
+from spyder_notebook.widgets.client import NotebookClient
+
+
+class MockPlugin(QWidget):
+    def get_plugin_actions(self):
+        return []
+
+
+def test_notebookclient_get_kernel_id(qtbot, mocker):
+    """Basic unit test for NotebookClient.get_kernel_id()."""
+    plugin = MockPlugin()
+    client = NotebookClient(plugin, '/path/notebooks/ham.ipynb')
+    server_info = {'notebook_dir': '/path/notebooks',
+                   'url': 'fake_url',
+                   'token': 'fake_token'}
+    client.register(server_info)
+    response = mocker.Mock()
+    response.content = (b'[{"kernel": {"id": "42"},'
+                        b'  "notebook": {"path": "ham.ipynb"}}]')
+    mocker.patch('requests.get', return_value=response)
+    kernel_id = client.get_kernel_id()
+    assert kernel_id == '42'

--- a/spyder_notebook/widgets/tests/test_client.py
+++ b/spyder_notebook/widgets/tests/test_client.py
@@ -6,6 +6,7 @@
 """Tests for client.py covering NotebookClient."""
 
 # Third-party imports
+import pytest
 from qtpy.QtWidgets import QWidget
 
 # Local imports
@@ -17,17 +18,37 @@ class MockPlugin(QWidget):
         return []
 
 
-def test_notebookclient_get_kernel_id(qtbot, mocker):
-    """Basic unit test for NotebookClient.get_kernel_id()."""
+@pytest.fixture
+def client(qtbot):
+    """Construct a NotebookClient for use in tests."""
     plugin = MockPlugin()
     client = NotebookClient(plugin, '/path/notebooks/ham.ipynb')
     server_info = {'notebook_dir': '/path/notebooks',
                    'url': 'fake_url',
                    'token': 'fake_token'}
     client.register(server_info)
+    return client
+
+
+def test_notebookclient_get_kernel_id(client, mocker):
+    """Basic unit test for NotebookClient.get_kernel_id()."""
     response = mocker.Mock()
-    response.content = (b'[{"kernel": {"id": "42"},'
-                        b'  "notebook": {"path": "ham.ipynb"}}]')
+    content = b'[{"kernel": {"id": "42"}, "notebook": {"path": "ham.ipynb"}}]'
+    response.content = content
     mocker.patch('requests.get', return_value=response)
+
     kernel_id = client.get_kernel_id()
     assert kernel_id == '42'
+
+
+def test_notebookclient_get_kernel_id_with_fields_missing(client, mocker):
+    """Test NotebookClient.get_kernel_id() if response has fields missing."""
+    response = mocker.Mock()
+    content = (b'[{"kernel": {"id": "1"}, "notebook": {"spam": "eggs"}},'
+               b' {"kernel": {"id": "2"}},'
+               b' {"kernel": {"id": "3"}, "notebook": {"path": "ham.ipynb"}}]')
+    response.content = content
+    mocker.patch('requests.get', return_value=response)
+
+    kernel_id = client.get_kernel_id()
+    assert kernel_id == '3'


### PR DESCRIPTION
Specifically, ignore sessions where the field for notebook path is not set. Also add tests for both the standard case and when the field is missing.

Fixes #153