### PR TITLE
PR: Update to Spyder 4 after the split-plugins merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,16 +22,19 @@ jobs:
     <<: *main
     environment:
       - PYTHON_VERSION: 2.7
+        SPYDER_BRANCH: 3.x
 
   python3.6:
     <<: *main
     environment:
       - PYTHON_VERSION: 3.6
+        SPYDER_BRANCH: 3.x
 
-  python3.7:
+  python3.7_spyder4:
     <<: *main
     environment:
       - PYTHON_VERSION: 3.7
+        SPYDER_BRANCH: master
 
 
 workflows:
@@ -40,4 +43,4 @@ workflows:
     jobs:
       - python2.7
       - python3.6
-      - python3.7
+      - python3.7_spyder4

--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -21,12 +21,12 @@ conda install -y --only-deps spyder
 # Download Spyder's source (3.x branch) from github 
 mkdir spyder-source
 pushd spyder-source
-wget -q https://github.com/spyder-ide/spyder/archive/3.x.zip
-unzip -q 3.x.zip
+wget -q https://github.com/spyder-ide/spyder/archive/$SPYDER_BRANCH.zip
+unzip -q $SPYDER_BRANCH.zip
 popd
 
 # Install Spyder from source
-pushd spyder-source/spyder-3.x
+pushd spyder-source/spyder-$SPYDER_BRANCH
 python setup.py install
 popd
 

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -29,7 +29,13 @@ from spyder.utils.programs import TEMPDIR
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
                                     add_actions, MENU_SEPARATOR)
 from spyder.widgets.tabs import Tabs
-from spyder.plugins import SpyderPluginWidget
+
+try:
+    # Spyder 4
+    from spyder.api.plugins import SpyderPluginWidget
+except ImportError:
+    # Spyder 3
+    from spyder.plugins import SpyderPluginWidget
 
 # Local imports
 from .utils.nbopen import nbopen, NBServerError

--- a/spyder_notebook/utils/nbopen.py
+++ b/spyder_notebook/utils/nbopen.py
@@ -20,6 +20,16 @@ import psutil
 from spyder.config.base import DEV, get_home_dir, get_module_path
 
 
+try:
+    # Spyder 4
+    from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
+    KERNELSPEC = ('spyder.plugins.ipythonconsole.utils'
+                  '.kernelspec.SpyderKernelSpec')
+except ImportError:
+    # Spyder 3
+    KERNELSPEC = 'spyder.utils.ipython.kernelspec.SpyderKernelSpec'
+
+
 class NBServerError(Exception):
     """Exception for notebook server errors."""
 
@@ -54,12 +64,11 @@ def nbopen(filename):
             nbdir = osp.dirname(filename)
 
         print("Starting new server")
-        kernelspec = 'spyder.utils.ipython.kernelspec.SpyderKernelSpec'
         command = ['jupyter', 'notebook', '--no-browser',
                    '--notebook-dir={}'.format(nbdir),
                    '--NotebookApp.password=',
                    "--KernelSpecManager.kernel_spec_class='{}'".format(
-                           kernelspec)]
+                           KERNELSPEC)]
 
         if os.name == 'nt':
             creation_flag = 0x08000000  # CREATE_NO_WINDOW

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -41,6 +41,11 @@ from ..widgets.dom import DOMWidget
 # Using the same css file from the Help plugin for now. Maybe
 # later it'll be a good idea to create a new one.
 try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError  # Python 2
+
+try:
     # Spyder 4
     PLUGINS_PATH = get_module_source_path('spyder', 'plugins')
     CSS_PATH = osp.join(PLUGINS_PATH, 'help', 'utils', 'static', 'css')

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -40,9 +40,18 @@ from ..widgets.dom import DOMWidget
 # -----------------------------------------------------------------------------
 # Using the same css file from the Help plugin for now. Maybe
 # later it'll be a good idea to create a new one.
-UTILS_PATH = get_module_source_path('spyder', 'utils')
-CSS_PATH = osp.join(UTILS_PATH, 'help', 'static', 'css')
-TEMPLATES_PATH = osp.join(UTILS_PATH, 'ipython', 'templates')
+try:
+    # Spyder 4
+    PLUGINS_PATH = get_module_source_path('spyder', 'plugins')
+    CSS_PATH = osp.join(PLUGINS_PATH, 'help', 'utils', 'static', 'css')
+    TEMPLATES_PATH = osp.join(
+            PLUGINS_PATH, 'ipythonconsole', 'assets', 'templates')
+    open(osp.join(TEMPLATES_PATH, 'blank.html'))
+except FileNotFoundError:
+    # Spyder 3
+    UTILS_PATH = get_module_source_path('spyder', 'utils')
+    CSS_PATH = osp.join(UTILS_PATH, 'help', 'static', 'css')
+    TEMPLATES_PATH = osp.join(UTILS_PATH, 'ipython', 'templates')
 
 BLANK = open(osp.join(TEMPLATES_PATH, 'blank.html')).read()
 LOADING = open(osp.join(TEMPLATES_PATH, 'loading.html')).read()


### PR DESCRIPTION
Update Spyder paths following the split-plugins merge, while maintaining compatibility with Spyder 3.

The plan is for spyder-notebook 0.1.x to be compatible with both Spyder 3 and Spyder 4, to allow for easy testing and development. To this end, this PR also changes one of the three CircleCI instances to test against Spyder's master branch. I expect that spyder-notebook 0.2.x will only support Spyder 4.

Fixes #158