### PR TITLE
PR: Specify Qt 5 in CI test script

### DIFF
--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -31,7 +31,8 @@ python setup.py install
 popd
 
 # Install spyder-notebook dependency
-conda install -y notebook
+# Specify Qt 5 to prevent Qt 4 being installed with Python 2
+conda install -y notebook qt=5
 
 # Install testing dependencies
 conda install -y pytest pytest-cov pytest-mock flaky


### PR DESCRIPTION
For some reason, if we don't specify `qt=5` then Qt 4 is installed when we are installing `notebook` with Python 2, which causes the tests to fail.

Fixes #183