### PR TITLE
PR: Avoid reading notebook file when closing tab

### DIFF
--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -177,6 +177,23 @@ def test_file_in_temp_dir_deleted_after_notebook_closed(notebook, qtbot):
     assert not osp.exists(filename)
 
 
+def test_close_nonexisting_notebook(notebook, qtbot):
+    """Test that we can close a tab if the notebook file does not exist.
+    Regression test for spyder-ide/spyder-notebook#187."""
+    # Set up tab with non-existingg notebook
+    filename = osp.join(LOCATION, 'does-not-exist.ipynb')
+    notebook.open_notebook(filenames=[filename])
+    nbwidget = notebook.get_current_nbwidget()
+    qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
+    client = notebook.get_current_client()
+
+    # Close tab
+    notebook.close_client()
+
+    # Assert tab is closed (without raising an exception)
+    assert client not in notebook.clients
+
+
 @flaky(max_runs=3)
 def test_open_notebook(notebook, qtbot, tmpdir_under_home):
     """Test that a notebook can be opened from a non-ascii directory."""


### PR DESCRIPTION
When the user closes a notebook tab, then the file name is checked to see whether the notebook was newly created (and thus stored in a temporary directory) and the notebook file is read to see whether the notebook contains anything. If both are the case, then the user is asked to save the notebook under a different name (and implicitly, in a permanent directory).

This PR reads the notebook file in this situation only if the file name indicates that the notebook was newly created. This is more efficient and it prevents errors when the user somehow opens a notebook file that does not exist. A regression test is added for the latter.

Fixes #187.