### PR TITLE
PR: Use _options_menu instead of options_menu in plugin

### DIFF
--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -80,10 +80,10 @@ class NotebookPlugin(SpyderPluginWidget):
         menu_btn = create_toolbutton(self, icon=ima.icon('tooloptions'),
                                      tip=_('Options'))
 
-        menu_btn.setMenu(self.options_menu)
+        menu_btn.setMenu(self._options_menu)
         menu_btn.setPopupMode(menu_btn.InstantPopup)
         corner_widgets = {Qt.TopRightCorner: [new_notebook_btn, menu_btn]}
-        self.tabwidget = Tabs(self, menu=self.options_menu,
+        self.tabwidget = Tabs(self, menu=self._options_menu,
                               actions=self.menu_actions,
                               corner_widgets=corner_widgets)
 

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -69,7 +69,6 @@ class NotebookPlugin(SpyderPluginWidget):
         self.untitled_num = 0
         self.recent_notebooks = self.get_option('recent_notebooks', default=[])
         self.recent_notebook_menu = QMenu(_("Open recent"), self)
-        self.options_menu = QMenu(self)
 
         layout = QVBoxLayout()
 
@@ -239,13 +238,9 @@ class NotebookPlugin(SpyderPluginWidget):
             if client.get_filename() != WELCOME:
                 self.save_as_action.setEnabled(True)
                 self.open_console_action.setEnabled(True)
-                self.options_menu.clear()
-                add_actions(self.options_menu, self.menu_actions)
                 return
         self.save_as_action.setEnabled(False)
         self.open_console_action.setEnabled(False)
-        self.options_menu.clear()
-        add_actions(self.options_menu, self.menu_actions)
 
     def add_to_recent(self, notebook):
         """


### PR DESCRIPTION
The name was changed in the base class in PR spyder-ide/spyder#9226.

Fixes #215 
Fixes #245 

