### PR TITLE
Add menu bar to notebook

### DIFF
--- a/spyder_notebook/server/index.css
+++ b/spyder_notebook/server/index.css
@@ -24,3 +24,8 @@ body {
 .notebookCommandPalette {
   min-width: 225px;
 }
+
+.notebookMenuBar {
+  border-bottom: 1px solid #bdbdbd;
+  min-height: 28px;
+}

--- a/spyder_notebook/server/index.css
+++ b/spyder_notebook/server/index.css
@@ -21,10 +21,6 @@ body {
   border-bottom: 1px solid #e0e0e0;
 }
 
-.notebookCommandPalette {
-  min-width: 225px;
-}
-
 .notebookMenuBar {
   border-bottom: 1px solid #bdbdbd;
   min-height: 28px;

--- a/spyder_notebook/server/src/commands.ts
+++ b/spyder_notebook/server/src/commands.ts
@@ -25,6 +25,22 @@ const cmdIds = {
   interrupt: 'notebook:interrupt-kernel',
   restart: 'notebook:restart-kernel',
   switchKernel: 'notebook:switch-kernel',
+  undo: 'notebook-cells:undo',
+  redo: 'notebook-cells:redo',
+  cut: 'notebook:cut-cell',
+  copy: 'notebook:copy-cell',
+  pasteAbove: 'notebook:paste-cell-above',
+  pasteBelow: 'notebook:paste-cell-below',
+  pasteAndReplace: 'notebook:paste-and-replace-cell',
+  deleteCell: 'notebook:delete-cell',
+  selectAll: 'notebook:select-all',
+  deselectAll: 'notebook:deselect-all',
+  moveUp: 'notebook:move-cell-up',
+  moveDown: 'notebook:move-cell-down',
+  split: 'notebook:split-cell-at-cursor',
+  merge: 'notebook:merge-cells',
+  clearOutputs: 'notebook:clear-cell-output',
+  clearAllOutputs: 'notebook:clear-all-cell-outputs',
   runAndAdvance: 'notebook-cells:run-and-advance',
   run: 'notebook:run-cell',
   runAndInsert: 'notebook-cells:run-cell-and-insert-below',
@@ -33,7 +49,6 @@ const cmdIds = {
   renderAllMarkdown: 'notebook-cells:render-all-markdown',
   runAll: 'notebook-cells:run-all-cells',
   restartRunAll: 'notebook:restart-run-all',
-  deleteCell: 'notebook-cells:delete',
   selectAbove: 'notebook-cells:select-above',
   selectBelow: 'notebook-cells:select-below',
   extendAbove: 'notebook-cells:extend-above',
@@ -41,11 +56,7 @@ const cmdIds = {
   extendBelow: 'notebook-cells:extend-below',
   extendBottom: 'notebook-cells:extend-bottom',
   editMode: 'notebook:edit-mode',
-  merge: 'notebook-cells:merge',
-  split: 'notebook-cells:split',
-  commandMode: 'notebook:command-mode',
-  undo: 'notebook-cells:undo',
-  redo: 'notebook-cells:redo'
+  commandMode: 'notebook:command-mode'
 };
 
 export const SetupCommands = (
@@ -158,6 +169,87 @@ export const SetupCommands = (
     }
     return true;
   }
+
+  // Commands in Edit menu.
+  commands.addCommand(cmdIds.undo, {
+    label: 'Undo',
+    execute: () => NotebookActions.undo(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.redo, {
+    label: 'Redo',
+    execute: () => NotebookActions.redo(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.cut, {
+    label: 'Cut Cells',
+    execute: () => NotebookActions.cut(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.copy, {
+    label: 'Copy Cells',
+    execute: () => NotebookActions.copy(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.pasteBelow, {
+    label: 'Paste Cells Below',
+    execute: () => NotebookActions.paste(nbWidget.content, 'below')
+  });
+
+  commands.addCommand(cmdIds.pasteAbove, {
+    label: 'Paste Cells Above',
+    execute: () => NotebookActions.paste(nbWidget.content, 'above')
+  });
+
+  commands.addCommand(cmdIds.pasteAndReplace, {
+    label: 'Paste Cells and Replace',
+    execute: () => NotebookActions.paste(nbWidget.content, 'replace')
+  });
+
+  commands.addCommand(cmdIds.deleteCell, {
+    label: 'Delete Cells',
+    execute: () => NotebookActions.deleteCells(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.selectAll, {
+    label: 'Select All Cells',
+    execute: () => NotebookActions.selectAll(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.deselectAll, {
+    label: 'Deselect All Cells',
+    execute: () => NotebookActions.deselectAll(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.moveUp, {
+    label: 'Move Cells Up',
+    execute: () => NotebookActions.moveUp(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.moveDown, {
+    label: 'Move Cells Down',
+    execute: () => NotebookActions.moveDown(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.split, {
+    label: 'Split Cell',
+    execute: () => NotebookActions.splitCell(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.merge, {
+    label: 'Merge Selected Cells',
+    execute: () => NotebookActions.mergeCells(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.clearOutputs, {
+    label: 'Clear Outputs',
+    execute: () => NotebookActions.clearOutputs(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.clearAllOutputs, {
+    label: 'Clear All Outputs',
+    execute: () => NotebookActions.clearAllOutputs(nbWidget.content)
+  });
 
   // Commands in Run menu.
   commands.addCommand(cmdIds.runAndAdvance, {
@@ -295,22 +387,6 @@ export const SetupCommands = (
     label: 'Extend to Bottom',
     execute: () => NotebookActions.extendSelectionBelow(nbWidget.content, true)
   });
-  commands.addCommand(cmdIds.merge, {
-    label: 'Merge Cells',
-    execute: () => NotebookActions.mergeCells(nbWidget.content)
-  });
-  commands.addCommand(cmdIds.split, {
-    label: 'Split Cell',
-    execute: () => NotebookActions.splitCell(nbWidget.content)
-  });
-  commands.addCommand(cmdIds.undo, {
-    label: 'Undo',
-    execute: () => NotebookActions.undo(nbWidget.content)
-  });
-  commands.addCommand(cmdIds.redo, {
-    label: 'Redo',
-    execute: () => NotebookActions.redo(nbWidget.content)
-  });
 
   let bindings = [
     {
@@ -421,10 +497,32 @@ export const SetupCommands = (
   ];
   bindings.map(binding => commands.addKeyBinding(binding));
 
+  // Create Edit menu.
+  let editMenu = new Menu({ commands });
+  editMenu.title.label = 'Edit';
+  editMenu.insertItem(0, { command: cmdIds.undo });
+  editMenu.insertItem(1, { command: cmdIds.redo });
+  editMenu.insertItem(2, { type: 'separator' });
+  editMenu.insertItem(3, { command: cmdIds.cut });
+  editMenu.insertItem(4, { command: cmdIds.copy });
+  editMenu.insertItem(5, { command: cmdIds.pasteAbove });
+  editMenu.insertItem(6, { command: cmdIds.pasteBelow});
+  editMenu.insertItem(7, { command: cmdIds.pasteAndReplace });
+  editMenu.insertItem(8, { type: 'separator' });
+  editMenu.insertItem(9, { command: cmdIds.deleteCell });
+  editMenu.insertItem(10, { type: 'separator' });
+  editMenu.insertItem(11, { command: cmdIds.moveUp });
+  editMenu.insertItem(12, { command: cmdIds.moveDown });
+  editMenu.insertItem(13, { type: 'separator' });
+  editMenu.insertItem(14, { command: cmdIds.split});
+  editMenu.insertItem(15, { command: cmdIds.merge});
+  editMenu.insertItem(16, { type: 'separator' });
+  editMenu.insertItem(17, { command: cmdIds.clearOutputs });
+  editMenu.insertItem(18, { command: cmdIds.clearAllOutputs });
+
   // Create Run menu.
   let runMenu = new Menu({ commands });
   runMenu.title.label = 'Run';
-  menuBar.insertMenu(0, runMenu);
   runMenu.insertItem(0, { command: cmdIds.runAndAdvance });
   runMenu.insertItem(1, { command: cmdIds.run });
   runMenu.insertItem(2, { command: cmdIds.runAndInsert });
@@ -433,4 +531,8 @@ export const SetupCommands = (
   runMenu.insertItem(5, { command: cmdIds.renderAllMarkdown });
   runMenu.insertItem(6, { command: cmdIds.runAll });
   runMenu.insertItem(7, { command: cmdIds.restartRunAll });
+
+  // Insert menus in menu bar.
+  menuBar.insertMenu(0, editMenu);
+  menuBar.insertMenu(1, runMenu);
 };

--- a/spyder_notebook/server/src/commands.ts
+++ b/spyder_notebook/server/src/commands.ts
@@ -8,7 +8,6 @@ import {
   SearchInstance,
   NotebookSearchProvider
 } from '@jupyterlab/documentsearch';
-import { CommandPalette } from '@phosphor/widgets';
 
 /**
  * The map of command ids used by the notebook.
@@ -44,7 +43,6 @@ const cmdIds = {
 
 export const SetupCommands = (
   commands: CommandRegistry,
-  palette: CommandPalette,
   nbWidget: NotebookPanel,
   handler: CompletionHandler
 ) => {
@@ -206,32 +204,6 @@ export const SetupCommands = (
     label: 'Redo',
     execute: () => NotebookActions.redo(nbWidget.content)
   });
-
-  let category = 'Notebook Operations';
-  [
-    cmdIds.interrupt,
-    cmdIds.restart,
-    cmdIds.editMode,
-    cmdIds.commandMode,
-    cmdIds.switchKernel,
-    cmdIds.startSearch,
-    cmdIds.findNext,
-    cmdIds.findPrevious
-  ].forEach(command => palette.addItem({ command, category }));
-
-  category = 'Notebook Cell Operations';
-  [
-    cmdIds.runAndAdvance,
-    cmdIds.runAll,
-    cmdIds.split,
-    cmdIds.merge,
-    cmdIds.selectAbove,
-    cmdIds.selectBelow,
-    cmdIds.extendAbove,
-    cmdIds.extendBelow,
-    cmdIds.undo,
-    cmdIds.redo
-  ].forEach(command => palette.addItem({ command, category }));
 
   let bindings = [
     {

--- a/spyder_notebook/server/src/commands.ts
+++ b/spyder_notebook/server/src/commands.ts
@@ -22,9 +22,6 @@ const cmdIds = {
   findNext: 'documentsearch:find-next',
   findPrevious: 'documentsearch:find-previous',
   save: 'notebook:save',
-  interrupt: 'notebook:interrupt-kernel',
-  restart: 'notebook:restart-kernel',
-  switchKernel: 'notebook:switch-kernel',
   undo: 'notebook-cells:undo',
   redo: 'notebook-cells:redo',
   cut: 'notebook:cut-cell',
@@ -41,6 +38,14 @@ const cmdIds = {
   merge: 'notebook:merge-cells',
   clearOutputs: 'notebook:clear-cell-output',
   clearAllOutputs: 'notebook:clear-all-cell-outputs',
+  hideCode: 'notebook:hide-cell-code',
+  hideOutput: 'notebook:hide-cell-outputs',
+  hideAllCode: 'notebook:hide-all-cell-code',
+  hideAllOutputs: 'notebook:hide-all-cell-outputs',
+  showCode: 'notebook:show-cell-code',
+  showOutput: 'notebook:show-cell-outputs',
+  showAllCode: 'notebook:show-all-cell-code',
+  showAllOutputs: 'notebook:show-all-cell-outputs',
   runAndAdvance: 'notebook-cells:run-and-advance',
   run: 'notebook:run-cell',
   runAndInsert: 'notebook-cells:run-cell-and-insert-below',
@@ -49,6 +54,11 @@ const cmdIds = {
   renderAllMarkdown: 'notebook-cells:render-all-markdown',
   runAll: 'notebook-cells:run-all-cells',
   restartRunAll: 'notebook:restart-run-all',
+  interrupt: 'notebook:interrupt-kernel',
+  restart: 'notebook:restart-kernel',
+  restartClear: 'notebook:restart-clear-output',
+  shutdown: 'notebook:shutdown-kernel',
+  switchKernel: 'notebook:switch-kernel',
   selectAbove: 'notebook-cells:select-above',
   selectBelow: 'notebook-cells:select-below',
   extendAbove: 'notebook-cells:extend-above',
@@ -65,94 +75,6 @@ export const SetupCommands = (
   nbWidget: NotebookPanel,
   handler: CompletionHandler
 ) => {
-  // Add commands.
-  commands.addCommand(cmdIds.invoke, {
-    label: 'Completer: Invoke',
-    execute: () => handler.invoke()
-  });
-  commands.addCommand(cmdIds.select, {
-    label: 'Completer: Select',
-    execute: () => handler.completer.selectActive()
-  });
-  commands.addCommand(cmdIds.invokeNotebook, {
-    label: 'Invoke Notebook',
-    execute: () => {
-      if (nbWidget.content.activeCell.model.type === 'code') {
-        return commands.execute(cmdIds.invoke);
-      }
-    }
-  });
-  commands.addCommand(cmdIds.selectNotebook, {
-    label: 'Select Notebook',
-    execute: () => {
-      if (nbWidget.content.activeCell.model.type === 'code') {
-        return commands.execute(cmdIds.select);
-      }
-    }
-  });
-  commands.addCommand(cmdIds.save, {
-    label: 'Save',
-    execute: () => nbWidget.context.save()
-  });
-
-  let searchInstance: SearchInstance;
-  commands.addCommand(cmdIds.startSearch, {
-    label: 'Find...',
-    execute: () => {
-      if (searchInstance) {
-        searchInstance.focusInput();
-        return;
-      }
-      const provider = new NotebookSearchProvider();
-      searchInstance = new SearchInstance(nbWidget, provider);
-      searchInstance.disposed.connect(() => {
-        searchInstance = undefined;
-        // find next and previous are now not enabled
-        commands.notifyCommandChanged();
-      });
-      // find next and previous are now enabled
-      commands.notifyCommandChanged();
-      searchInstance.focusInput();
-    }
-  });
-  commands.addCommand(cmdIds.findNext, {
-    label: 'Find Next',
-    isEnabled: () => !!searchInstance,
-    execute: async () => {
-      if (!searchInstance) {
-        return;
-      }
-      await searchInstance.provider.highlightNext();
-      searchInstance.updateIndices();
-    }
-  });
-  commands.addCommand(cmdIds.findPrevious, {
-    label: 'Find Previous',
-    isEnabled: () => !!searchInstance,
-    execute: async () => {
-      if (!searchInstance) {
-        return;
-      }
-      await searchInstance.provider.highlightPrevious();
-      searchInstance.updateIndices();
-    }
-  });
-  commands.addCommand(cmdIds.interrupt, {
-    label: 'Interrupt',
-    execute: async () => {
-      if (nbWidget.context.session.kernel) {
-        await nbWidget.context.session.kernel.interrupt();
-      }
-    }
-  });
-  commands.addCommand(cmdIds.restart, {
-    label: 'Restart Kernel',
-    execute: () => nbWidget.context.session.restart()
-  });
-  commands.addCommand(cmdIds.switchKernel, {
-    label: 'Switch Kernel',
-    execute: () => nbWidget.context.session.selectKernel()
-  });
 
   /**
    * Whether notebook has a single selected cell.
@@ -249,6 +171,47 @@ export const SetupCommands = (
   commands.addCommand(cmdIds.clearAllOutputs, {
     label: 'Clear All Outputs',
     execute: () => NotebookActions.clearAllOutputs(nbWidget.content)
+  });
+
+  // Commands in View menu.
+  commands.addCommand(cmdIds.hideCode, {
+    label: 'Collapse Selected Code',
+    execute: () => NotebookActions.hideCode(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.hideOutput, {
+    label: 'Collapse Selected Outputs',
+    execute: () => NotebookActions.hideOutput(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.hideAllCode, {
+    label: 'Collapse All Code',
+    execute: () => NotebookActions.hideAllCode(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.hideAllOutputs, {
+    label: 'Collapse All Outputs',
+    execute: () => NotebookActions.hideAllOutputs(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.showCode, {
+    label: 'Expand Selected Code',
+    execute: () => NotebookActions.showCode(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.showOutput, {
+    label: 'Expand Selected Outputs',
+    execute: () => NotebookActions.showOutput(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.showAllCode, {
+    label: 'Expand All Code',
+    execute: () => NotebookActions.showAllCode(nbWidget.content)
+  });
+
+  commands.addCommand(cmdIds.showAllOutputs, {
+    label: 'Expand All Outputs',
+    execute: () => NotebookActions.showAllOutputs(nbWidget.content)
   });
 
   // Commands in Run menu.
@@ -351,6 +314,110 @@ export const SetupCommands = (
     }
   });
 
+  // Commands in Kernel menu.
+  commands.addCommand(cmdIds.interrupt, {
+    label: 'Interrupt Kernel',
+    execute: async () => {
+      if (nbWidget.context.session.kernel) {
+        await nbWidget.context.session.kernel.interrupt();
+      }
+    }
+  });
+
+  commands.addCommand(cmdIds.restart, {
+    label: 'Restart Kernel…',
+    execute: () => nbWidget.context.session.restart()
+  });
+
+  commands.addCommand(cmdIds.restartClear, {
+    label: 'Restart Kernel and Clear All Outputs…',
+    execute: () => nbWidget.context.session.restart().then(() => {
+      NotebookActions.clearAllOutputs(nbWidget.content);
+    })
+  });
+
+  commands.addCommand(cmdIds.shutdown, {
+    label: 'Shutdown Kernel',
+    execute: () => nbWidget.context.session.shutdown()
+  });
+
+  commands.addCommand(cmdIds.switchKernel, {
+    label: 'Change Kernel…',
+    execute: () => nbWidget.context.session.selectKernel()
+  });
+
+  // Add other commands.
+  commands.addCommand(cmdIds.invoke, {
+    label: 'Completer: Invoke',
+    execute: () => handler.invoke()
+  });
+  commands.addCommand(cmdIds.select, {
+    label: 'Completer: Select',
+    execute: () => handler.completer.selectActive()
+  });
+  commands.addCommand(cmdIds.invokeNotebook, {
+    label: 'Invoke Notebook',
+    execute: () => {
+      if (nbWidget.content.activeCell.model.type === 'code') {
+        return commands.execute(cmdIds.invoke);
+      }
+    }
+  });
+  commands.addCommand(cmdIds.selectNotebook, {
+    label: 'Select Notebook',
+    execute: () => {
+      if (nbWidget.content.activeCell.model.type === 'code') {
+        return commands.execute(cmdIds.select);
+      }
+    }
+  });
+  commands.addCommand(cmdIds.save, {
+    label: 'Save',
+    execute: () => nbWidget.context.save()
+  });
+
+  let searchInstance: SearchInstance;
+  commands.addCommand(cmdIds.startSearch, {
+    label: 'Find...',
+    execute: () => {
+      if (searchInstance) {
+        searchInstance.focusInput();
+        return;
+      }
+      const provider = new NotebookSearchProvider();
+      searchInstance = new SearchInstance(nbWidget, provider);
+      searchInstance.disposed.connect(() => {
+        searchInstance = undefined;
+        // find next and previous are now not enabled
+        commands.notifyCommandChanged();
+      });
+      // find next and previous are now enabled
+      commands.notifyCommandChanged();
+      searchInstance.focusInput();
+    }
+  });
+  commands.addCommand(cmdIds.findNext, {
+    label: 'Find Next',
+    isEnabled: () => !!searchInstance,
+    execute: async () => {
+      if (!searchInstance) {
+        return;
+      }
+      await searchInstance.provider.highlightNext();
+      searchInstance.updateIndices();
+    }
+  });
+  commands.addCommand(cmdIds.findPrevious, {
+    label: 'Find Previous',
+    isEnabled: () => !!searchInstance,
+    execute: async () => {
+      if (!searchInstance) {
+        return;
+      }
+      await searchInstance.provider.highlightPrevious();
+      searchInstance.updateIndices();
+    }
+  });
   commands.addCommand(cmdIds.editMode, {
     label: 'Edit Mode',
     execute: () => {
@@ -520,6 +587,19 @@ export const SetupCommands = (
   editMenu.insertItem(17, { command: cmdIds.clearOutputs });
   editMenu.insertItem(18, { command: cmdIds.clearAllOutputs });
 
+  // Create View menu.
+  let viewMenu = new Menu({ commands });
+  viewMenu.title.label = 'View';
+  viewMenu.insertItem(0, { command: cmdIds.hideCode });
+  viewMenu.insertItem(1, { command: cmdIds.hideOutput });
+  viewMenu.insertItem(2, { command: cmdIds.hideAllCode });
+  viewMenu.insertItem(3, { command: cmdIds.hideAllOutputs });
+  viewMenu.insertItem(4, { type: 'separator' });
+  viewMenu.insertItem(5, { command: cmdIds.showCode });
+  viewMenu.insertItem(6, { command: cmdIds.showOutput });
+  viewMenu.insertItem(7, { command: cmdIds.showAllCode });
+  viewMenu.insertItem(8, { command: cmdIds.showAllOutputs });
+
   // Create Run menu.
   let runMenu = new Menu({ commands });
   runMenu.title.label = 'Run';
@@ -532,7 +612,19 @@ export const SetupCommands = (
   runMenu.insertItem(6, { command: cmdIds.runAll });
   runMenu.insertItem(7, { command: cmdIds.restartRunAll });
 
+  // Create Kernel menu.
+  let kernelMenu = new Menu({ commands });
+  kernelMenu.title.label = 'Kernel';
+  kernelMenu.insertItem(0, { command: cmdIds.interrupt });
+  kernelMenu.insertItem(1, { command: cmdIds.restart });
+  kernelMenu.insertItem(2, { command: cmdIds.restartClear });
+  kernelMenu.insertItem(3, { command: cmdIds.restartRunAll});
+  kernelMenu.insertItem(4, { command: cmdIds.shutdown });
+  kernelMenu.insertItem(4, { command: cmdIds.switchKernel });
+
   // Insert menus in menu bar.
   menuBar.insertMenu(0, editMenu);
-  menuBar.insertMenu(1, runMenu);
+  menuBar.insertMenu(1, viewMenu);
+  menuBar.insertMenu(2, runMenu);
+  menuBar.insertMenu(3, kernelMenu);
 };

--- a/spyder_notebook/server/src/commands.ts
+++ b/spyder_notebook/server/src/commands.ts
@@ -2,6 +2,7 @@
  * Set up keyboard shortcuts & commands for notebook
  */
 import { CommandRegistry } from '@phosphor/commands';
+import { Menu, MenuBar } from '@phosphor/widgets';
 import { CompletionHandler } from '@jupyterlab/completer';
 import { NotebookPanel, NotebookActions } from '@jupyterlab/notebook';
 import {
@@ -43,6 +44,7 @@ const cmdIds = {
 
 export const SetupCommands = (
   commands: CommandRegistry,
+  menuBar: MenuBar,
   nbWidget: NotebookPanel,
   handler: CompletionHandler
 ) => {
@@ -313,4 +315,10 @@ export const SetupCommands = (
     }
   ];
   bindings.map(binding => commands.addKeyBinding(binding));
+
+  // Create Run menu.
+  let runMenu = new Menu({ commands });
+  runMenu.title.label = 'Run';
+  menuBar.insertMenu(0, runMenu);
+  runMenu.insertItem(0, { command: cmdIds.runAll });
 };

--- a/spyder_notebook/server/src/index.ts
+++ b/spyder_notebook/server/src/index.ts
@@ -14,7 +14,6 @@ import '../index.css';
 import { CommandRegistry } from '@phosphor/commands';
 
 import {
-  CommandPalette,
   Menu,
   MenuBar,
   SplitPanel,
@@ -110,8 +109,6 @@ function createApp(manager: ServiceManager.IManager): void {
 
   let notebookPath = PageConfig.getOption('notebookPath');
   let nbWidget = docManager.open(notebookPath) as NotebookPanel;
-  let palette = new CommandPalette({ commands });
-  palette.addClass('notebookCommandPalette');
 
   // create menu bar
   let menuBar = new MenuBar();
@@ -138,23 +135,14 @@ function createApp(manager: ServiceManager.IManager): void {
   // Hide the widget when it first loads.
   completer.hide();
 
-  let hpanel = new SplitPanel();
-  hpanel.id = 'subpanel';
-  hpanel.orientation = 'horizontal';
-  hpanel.spacing = 0;
-  SplitPanel.setStretch(palette, 0);
-  SplitPanel.setStretch(nbWidget, 1);
-  hpanel.addWidget(palette);
-  hpanel.addWidget(nbWidget);
-
   let panel = new SplitPanel();
   panel.id = 'main';
   panel.orientation = 'vertical';
   panel.spacing = 0;
   SplitPanel.setStretch(menuBar, 0);
-  SplitPanel.setStretch(hpanel, 1);
+  SplitPanel.setStretch(nbWidget, 1);
   panel.addWidget(menuBar);
-  panel.addWidget(hpanel);
+  panel.addWidget(nbWidget);
 
   // Attach the panel to the DOM.
   Widget.attach(panel, document.body);
@@ -165,7 +153,7 @@ function createApp(manager: ServiceManager.IManager): void {
     panel.update();
   });
 
-  SetupCommands(commands, palette, nbWidget, handler);
+  SetupCommands(commands, nbWidget, handler);
 
   console.log('Example started!');
 }

--- a/spyder_notebook/server/src/index.ts
+++ b/spyder_notebook/server/src/index.ts
@@ -13,7 +13,13 @@ import '../index.css';
 
 import { CommandRegistry } from '@phosphor/commands';
 
-import { CommandPalette, SplitPanel, Widget } from '@phosphor/widgets';
+import {
+  CommandPalette,
+  Menu,
+  MenuBar,
+  SplitPanel,
+  Widget
+} from '@phosphor/widgets';
 
 import { ServiceManager } from '@jupyterlab/services';
 import { MathJaxTypesetter } from '@jupyterlab/mathjax2';
@@ -107,6 +113,13 @@ function createApp(manager: ServiceManager.IManager): void {
   let palette = new CommandPalette({ commands });
   palette.addClass('notebookCommandPalette');
 
+  // create menu bar
+  let menuBar = new MenuBar();
+  let menu = new Menu({ commands });
+  menu.title.label = 'Ham';
+  menuBar.insertMenu(0, menu);
+  menuBar.addClass('notebookMenuBar');
+
   const editor =
     nbWidget.content.activeCell && nbWidget.content.activeCell.editor;
   const model = new CompleterModel();
@@ -125,14 +138,23 @@ function createApp(manager: ServiceManager.IManager): void {
   // Hide the widget when it first loads.
   completer.hide();
 
-  let panel = new SplitPanel();
-  panel.id = 'main';
-  panel.orientation = 'horizontal';
-  panel.spacing = 0;
+  let hpanel = new SplitPanel();
+  hpanel.id = 'subpanel';
+  hpanel.orientation = 'horizontal';
+  hpanel.spacing = 0;
   SplitPanel.setStretch(palette, 0);
   SplitPanel.setStretch(nbWidget, 1);
-  panel.addWidget(palette);
-  panel.addWidget(nbWidget);
+  hpanel.addWidget(palette);
+  hpanel.addWidget(nbWidget);
+
+  let panel = new SplitPanel();
+  panel.id = 'main';
+  panel.orientation = 'vertical';
+  panel.spacing = 0;
+  SplitPanel.setStretch(menuBar, 0);
+  SplitPanel.setStretch(hpanel, 1);
+  panel.addWidget(menuBar);
+  panel.addWidget(hpanel);
 
   // Attach the panel to the DOM.
   Widget.attach(panel, document.body);

--- a/spyder_notebook/server/src/index.ts
+++ b/spyder_notebook/server/src/index.ts
@@ -13,12 +13,7 @@ import '../index.css';
 
 import { CommandRegistry } from '@phosphor/commands';
 
-import {
-  Menu,
-  MenuBar,
-  SplitPanel,
-  Widget
-} from '@phosphor/widgets';
+import { MenuBar, SplitPanel, Widget } from '@phosphor/widgets';
 
 import { ServiceManager } from '@jupyterlab/services';
 import { MathJaxTypesetter } from '@jupyterlab/mathjax2';
@@ -110,11 +105,8 @@ function createApp(manager: ServiceManager.IManager): void {
   let notebookPath = PageConfig.getOption('notebookPath');
   let nbWidget = docManager.open(notebookPath) as NotebookPanel;
 
-  // create menu bar
+  // Create menu bar.
   let menuBar = new MenuBar();
-  let menu = new Menu({ commands });
-  menu.title.label = 'Ham';
-  menuBar.insertMenu(0, menu);
   menuBar.addClass('notebookMenuBar');
 
   const editor =
@@ -135,6 +127,7 @@ function createApp(manager: ServiceManager.IManager): void {
   // Hide the widget when it first loads.
   completer.hide();
 
+  // Create panel with menu bar above the notebook widget
   let panel = new SplitPanel();
   panel.id = 'main';
   panel.orientation = 'vertical';
@@ -153,9 +146,7 @@ function createApp(manager: ServiceManager.IManager): void {
     panel.update();
   });
 
-  SetupCommands(commands, nbWidget, handler);
-
-  console.log('Example started!');
+  SetupCommands(commands, menuBar, nbWidget, handler);
 }
 
 window.addEventListener('load', main);


### PR DESCRIPTION
This adds a menu bar to the rendered notebook and removes the side bar with the command palette. The menu bar is filled with items defined in the notebook component of Jupyter lab. 

Compared to Jupyter lab, the File, Tab, Settings and Help menus are missing. These are defined in other components so they are not so easy to include, and in many cases they require thought on how to integrate them properly in Spyder.

Fixes #270.

![spydernb-menu](https://user-images.githubusercontent.com/7941918/82432759-6b05e680-9a88-11ea-9f48-95a50c7515b0.gif)
