### PR TITLE
PR: Split off part of NotebookPlugin into NotebookTabWidget

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
-omit = */tests/*
+omit =
+    */tests/*
+    spyder_notebook/widgets/example_app.py
 
 [report]
 fail_under=0

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -77,7 +77,7 @@ class NotebookPlugin(SpyderPluginWidget):
         corner_widgets = {Qt.TopRightCorner: [new_notebook_btn, menu_btn]}
         self.tabwidget = NotebookTabWidget(
             self, menu=self._options_menu, actions=self.menu_actions,
-            corner_widgets=corner_widgets, testing=testing)
+            corner_widgets=corner_widgets)
 
         self.tabwidget.currentChanged.connect(self.refresh_plugin)
 

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -13,7 +13,7 @@ import os.path as osp
 from qtpy import PYQT4, PYSIDE
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication, QMessageBox, QVBoxLayout, QMenu
+from qtpy.QtWidgets import QMessageBox, QVBoxLayout, QMenu
 
 # Spyder imports
 from spyder.api.plugins import SpyderPluginWidget
@@ -26,7 +26,6 @@ from spyder.utils.switcher import shorten_paths
 
 
 # Local imports
-from spyder_notebook.widgets.client import NotebookClient
 from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 
 
@@ -239,33 +238,6 @@ class NotebookPlugin(SpyderPluginWidget):
         """Clear the list of recent notebooks."""
         self.recent_notebooks = []
         self.setup_menu_actions()
-
-    def get_clients(self):
-        """Return notebooks list."""
-        return [cl for cl in self.tabwidget.clients
-                if isinstance(cl, NotebookClient)]
-
-    def get_focus_client(self):
-        """Return current notebook with focus, if any."""
-        widget = QApplication.focusWidget()
-        for client in self.get_clients():
-            if widget is client or widget is client.notebookwidget:
-                return client
-
-    def get_current_nbwidget(self):
-        """Return the notebookwidget of the current client."""
-        client = self.tabwidget.currentWidget()
-        if client is not None:
-            return client.notebookwidget
-
-    def get_current_client_name(self, short=False):
-        """Get the current client name."""
-        client = self.tabwidget.currentWidget()
-        if client:
-            if short:
-                return client.get_short_name()
-            else:
-                return client.get_filename()
 
     def create_new_client(self, filename=None):
         """Create a new notebook or load a pre-existing one."""

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -167,7 +167,7 @@ class NotebookPlugin(SpyderPluginWidget):
         super().register_plugin()
         self.focus_changed.connect(self.main.plugin_focus_changed)
         self.ipyconsole = self.main.ipyconsole
-        self.create_new_client(give_focus=False)
+        self.create_new_client()
 
         # Connect to switcher
         self.switcher = self.main.switcher
@@ -279,7 +279,7 @@ class NotebookPlugin(SpyderPluginWidget):
             else:
                 return client.get_filename()
 
-    def create_new_client(self, filename=None, give_focus=True):
+    def create_new_client(self, filename=None):
         """Create a new notebook or load a pre-existing one."""
         # Save spyder_pythonpath before creating a client
         # because it's needed by our kernel spec.
@@ -287,7 +287,7 @@ class NotebookPlugin(SpyderPluginWidget):
             self.set_option('main/spyder_pythonpath',
                             self.main.get_spyder_pythonpath())
 
-        filename = self.tabwidget.create_new_client(filename, give_focus)
+        filename = self.tabwidget.create_new_client(filename)
         if NOTEBOOK_TMPDIR not in filename:
             self.add_to_recent(filename)
             self.setup_menu_actions()

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -317,10 +317,10 @@ class NotebookPlugin(SpyderPluginWidget):
             # Create a welcome widget
             # See issue 93
             self.untitled_num -= 1
-            self.create_welcome_client()
+            self.maybe_create_welcome_client()
             return
 
-        welcome_client = self.create_welcome_client()
+        welcome_client = self.tabwidget.maybe_create_welcome_client()
         client = NotebookClient(self, filename, self.menu_actions)
         self.tabwidget.add_tab(client)
         if NOTEBOOK_TMPDIR not in filename:
@@ -365,16 +365,7 @@ class NotebookPlugin(SpyderPluginWidget):
         self.tabwidget.removeTab(self.tabwidget.indexOf(client))
         self.tabwidget.clients.remove(client)
 
-        self.create_welcome_client()
-
-    def create_welcome_client(self):
-        """Create a welcome client with some instructions."""
-        if self.tabwidget.count() == 0:
-            welcome = open(WELCOME).read()
-            client = NotebookClient(
-                self, WELCOME, self.menu_actions, ini_message=welcome)
-            self.tabwidget.add_tab(client)
-            return client
+        self.tabwidget.maybe_create_welcome_client()
 
     def save_notebook(self, client):
         """

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -214,7 +214,7 @@ class NotebookPlugin(SpyderPluginWidget):
         else:
             self.clear_recent_notebooks_action.setEnabled(False)
         try:
-            client = self.tabwidget.get_current_client()
+            client = self.tabwidget.currentWidget()
         except AttributeError:  # tabwidget is not yet constructed
             client = None
         if client:
@@ -254,13 +254,13 @@ class NotebookPlugin(SpyderPluginWidget):
 
     def get_current_nbwidget(self):
         """Return the notebookwidget of the current client."""
-        client = self.tabwidget.get_current_client()
+        client = self.tabwidget.currentWidget()
         if client is not None:
             return client.notebookwidget
 
     def get_current_client_name(self, short=False):
         """Get the current client name."""
-        client = self.tabwidget.get_current_client()
+        client = self.tabwidget.currentWidget()
         if client:
             if short:
                 return client.get_short_name()
@@ -297,7 +297,7 @@ class NotebookPlugin(SpyderPluginWidget):
     def open_console(self, client=None):
         """Open an IPython console for the given client or the current one."""
         if not client:
-            client = self.tabwidget.get_current_client()
+            client = self.tabwidget.currentWidget()
         if self.ipyconsole is not None:
             kernel_id = client.get_kernel_id()
             if not kernel_id:

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -59,9 +59,6 @@ class NotebookPlugin(SpyderPluginWidget):
         self.testing = testing
 
         self.fileswitcher_dlg = None
-        self.tabwidget = None
-        self.menu_actions = None
-
         self.main = parent
 
         self.untitled_num = 0
@@ -77,6 +74,7 @@ class NotebookPlugin(SpyderPluginWidget):
         menu_btn = create_toolbutton(self, icon=ima.icon('tooloptions'),
                                      tip=_('Options'))
 
+        self.menu_actions = self.get_plugin_actions()
         menu_btn.setMenu(self._options_menu)
         menu_btn.setPopupMode(menu_btn.InstantPopup)
         corner_widgets = {Qt.TopRightCorner: [new_notebook_btn, menu_btn]}
@@ -323,7 +321,7 @@ class NotebookPlugin(SpyderPluginWidget):
             return
 
         welcome_client = self.create_welcome_client()
-        client = NotebookClient(self, filename)
+        client = NotebookClient(self, filename, self.menu_actions)
         self.tabwidget.add_tab(client)
         if NOTEBOOK_TMPDIR not in filename:
             self.add_to_recent(filename)
@@ -373,7 +371,8 @@ class NotebookPlugin(SpyderPluginWidget):
         """Create a welcome client with some instructions."""
         if self.tabwidget.count() == 0:
             welcome = open(WELCOME).read()
-            client = NotebookClient(self, WELCOME, ini_message=welcome)
+            client = NotebookClient(
+                self, WELCOME, self.menu_actions, ini_message=welcome)
             self.tabwidget.add_tab(client)
             return client
 

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -9,7 +9,6 @@
 import os
 import os.path as osp
 import subprocess
-import sys
 
 # Qt imports
 from qtpy import PYQT4, PYSIDE
@@ -29,12 +28,12 @@ from spyder.utils.programs import get_temp_dir
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
                                     add_actions, MENU_SEPARATOR)
 from spyder.utils.switcher import shorten_paths
-from spyder.widgets.tabs import Tabs
 
 
 # Local imports
-from .utils.nbopen import nbopen, NBServerError
-from .widgets.client import NotebookClient
+from spyder_notebook.utils.nbopen import nbopen, NBServerError
+from spyder_notebook.widgets.client import NotebookClient
+from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 
 
 NOTEBOOK_TMPDIR = osp.join(get_temp_dir(), 'notebooks')
@@ -82,16 +81,10 @@ class NotebookPlugin(SpyderPluginWidget):
         menu_btn.setMenu(self._options_menu)
         menu_btn.setPopupMode(menu_btn.InstantPopup)
         corner_widgets = {Qt.TopRightCorner: [new_notebook_btn, menu_btn]}
-        self.tabwidget = Tabs(self, menu=self._options_menu,
-                              actions=self.menu_actions,
-                              corner_widgets=corner_widgets)
+        self.tabwidget = NotebookTabWidget(
+            self, menu=self._options_menu, actions=self.menu_actions,
+            corner_widgets=corner_widgets)
 
-        if hasattr(self.tabwidget, 'setDocumentMode') \
-           and not sys.platform == 'darwin':
-            # Don't set document mode to true on OSX because it generates
-            # a crash when the console is detached from the main window
-            # Fixes Issue 561
-            self.tabwidget.setDocumentMode(True)
         self.tabwidget.currentChanged.connect(self.refresh_plugin)
 
         self.tabwidget.set_close_function(self.close_client)

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -93,7 +93,6 @@ class NotebookPlugin(SpyderPluginWidget):
             # Fixes Issue 561
             self.tabwidget.setDocumentMode(True)
         self.tabwidget.currentChanged.connect(self.refresh_plugin)
-        self.tabwidget.move_data.connect(self.move_tab)
 
         self.tabwidget.set_close_function(self.close_client)
 
@@ -487,11 +486,6 @@ class NotebookPlugin(SpyderPluginWidget):
         if self.dockwidget:
             self.switch_to_plugin()
         self.activateWindow()
-
-    def move_tab(self, index_from, index_to):
-        """Move tab."""
-        client = self.clients.pop(index_from)
-        self.clients.insert(index_to, client)
 
     # ------ Public API (for FileSwitcher) ------------------------------------
     def handle_switcher_modes(self, mode):

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -324,7 +324,7 @@ class NotebookPlugin(SpyderPluginWidget):
 
         welcome_client = self.create_welcome_client()
         client = NotebookClient(self, filename)
-        self.add_tab(client)
+        self.tabwidget.add_tab(client)
         if NOTEBOOK_TMPDIR not in filename:
             self.add_to_recent(filename)
             self.setup_menu_actions()
@@ -374,7 +374,7 @@ class NotebookPlugin(SpyderPluginWidget):
         if self.tabwidget.count() == 0:
             welcome = open(WELCOME).read()
             client = NotebookClient(self, WELCOME, ini_message=welcome)
-            self.add_tab(client)
+            self.tabwidget.add_tab(client)
             return client
 
     def save_notebook(self, client):
@@ -468,17 +468,6 @@ class NotebookPlugin(SpyderPluginWidget):
             ipyclient.allow_rename = False
             self.ipyconsole.rename_client_tab(ipyclient,
                                               client.get_short_name())
-
-    # ------ Public API (for tabs) --------------------------------------------
-    def add_tab(self, widget):
-        """Add tab."""
-        self.tabwidget.clients.append(widget)
-        index = self.tabwidget.addTab(widget, widget.get_short_name())
-        self.tabwidget.setCurrentIndex(index)
-        self.tabwidget.setTabToolTip(index, widget.get_filename())
-        if self.dockwidget:
-            self.switch_to_plugin()
-        self.activateWindow()
 
     # ------ Public API (for FileSwitcher) ------------------------------------
     def handle_switcher_modes(self, mode):

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -108,8 +108,8 @@ class NotebookPlugin(SpyderPluginWidget):
 
     def closing_plugin(self, cancelable=False):
         """Perform actions before parent main window is closed."""
-        for cl in self.tabwidget.clients:
-            cl.close()
+        for client_index in range(self.tabwidget.count()):
+            self.tabwidget.widget(client_index).close()
         self.set_option('recent_notebooks', self.recent_notebooks)
         return True
 
@@ -295,19 +295,20 @@ class NotebookPlugin(SpyderPluginWidget):
         if mode != '':
             return
 
-        paths = [client.get_filename() for client in self.tabwidget.clients]
-        is_unsaved = [False for client in self.tabwidget.clients]
+        clients = [self.tabwidget.widget(i)
+                   for i in range(self.tabwidget.count())]
+        paths = [client.get_filename() for client in clients]
+        is_unsaved = [False for client in clients]
         short_paths = shorten_paths(paths, is_unsaved)
         icon = QIcon(os.path.join(PACKAGE_PATH, 'images', 'icon.svg'))
         section = self.get_plugin_title()
 
-        for path, short_path, client in zip(
-                paths, short_paths, self.tabwidget.clients):
+        for path, short_path, client in zip(paths, short_paths, clients):
             title = osp.basename(path)
             description = osp.dirname(path)
             if len(path) > 75:
                 description = short_path
-            is_last_item = (client == self.tabwidget.clients[-1])
+            is_last_item = (client == clients[-1])
             self.switcher.add_item(
                 title=title, description=description, icon=icon,
                 section=section, data=client, last_item=is_last_item)
@@ -324,7 +325,7 @@ class NotebookPlugin(SpyderPluginWidget):
             return
 
         client = item.get_data()
-        index = self.tabwidget.clients.index(client)
+        index = self.tabwidget.indexOf(client)
         self.tabwidget.setCurrentIndex(index)
         self.switch_to_plugin()
         self.switcher.hide()

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -94,10 +94,12 @@ def is_kernel_up(kernel_id, sessions_url):
 # =============================================================================
 @pytest.fixture
 def notebook(qtbot):
-    """Set up the Notebook plugin."""
+    """Set up the Notebook plugin with a welcome tab and a tab with a new
+    notebook. The latter tab is selected."""
     notebook_plugin = NotebookPlugin(None, testing=True)
     qtbot.addWidget(notebook_plugin)
     notebook_plugin.create_new_client()
+    notebook_plugin.tabwidget.setCurrentIndex(1)
     return notebook_plugin
 
 

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -110,7 +110,7 @@ def notebook(qtbot):
 def test_shutdown_notebook_kernel(notebook, qtbot):
     """Test that kernel is shutdown from server when closing a notebook."""
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Get kernel id for the client
@@ -131,7 +131,7 @@ def test_file_in_temp_dir_deleted_after_notebook_closed(notebook, qtbot):
     """Test that notebook file in temporary directory is deleted after the
     notebook is closed."""
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Get file name
@@ -151,7 +151,7 @@ def test_close_nonexisting_notebook(notebook, qtbot):
     # Set up tab with non-existingg notebook
     filename = osp.join(LOCATION, 'does-not-exist.ipynb')
     notebook.open_notebook(filenames=[filename])
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
     client = notebook.tabwidget.currentWidget()
 
@@ -173,7 +173,7 @@ def test_open_notebook(notebook, qtbot, tmpdir):
 
     # Wait for prompt
     notebook.open_notebook(filenames=[test_notebook_non_ascii])
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Assert that the In prompt has "Test" in it
@@ -189,7 +189,7 @@ def test_open_notebook(notebook, qtbot, tmpdir):
 def test_save_notebook(notebook, qtbot, tmpdir):
     """Test that a notebook can be saved."""
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Writes: a = "test"
@@ -210,7 +210,7 @@ def test_save_notebook(notebook, qtbot, tmpdir):
     notebook.save_as()
 
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Assert that the In prompt has "test" in it
@@ -233,7 +233,7 @@ def test_save_notebook_as_with_error(mocker, notebook, qtbot, tmpdir):
                                  '.QMessageBox.critical')
 
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Save the notebook
@@ -247,7 +247,7 @@ def test_save_notebook_as_with_error(mocker, notebook, qtbot, tmpdir):
 def test_new_notebook(notebook, qtbot):
     """Test that a new client is really a notebook."""
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Assert that we have one notebook and the welcome page
@@ -261,7 +261,7 @@ def test_open_console_when_no_kernel(notebook, qtbot, mocker):
     MockMessageBox = mocker.patch('spyder_notebook.notebookplugin.QMessageBox')
 
     # Wait for prompt
-    nbwidget = notebook.get_current_nbwidget()
+    nbwidget = notebook.tabwidget.currentWidget().notebookwidget
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Shut the kernel down and check that this is successful

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -114,7 +114,7 @@ def test_shutdown_notebook_kernel(notebook, qtbot):
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Get kernel id for the client
-    client = notebook.tabwidget.get_current_client()
+    client = notebook.tabwidget.currentWidget()
     qtbot.waitUntil(lambda: client.get_kernel_id() is not None,
                     timeout=NOTEBOOK_UP)
     kernel_id = client.get_kernel_id()
@@ -135,7 +135,7 @@ def test_file_in_temp_dir_deleted_after_notebook_closed(notebook, qtbot):
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Get file name
-    client = notebook.tabwidget.get_current_client()
+    client = notebook.tabwidget.currentWidget()
     filename = client.get_filename()
 
     # Close the current client
@@ -153,7 +153,7 @@ def test_close_nonexisting_notebook(notebook, qtbot):
     notebook.open_notebook(filenames=[filename])
     nbwidget = notebook.get_current_nbwidget()
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
-    client = notebook.tabwidget.get_current_client()
+    client = notebook.tabwidget.currentWidget()
 
     # Close tab
     notebook.tabwidget.close_client()
@@ -180,7 +180,7 @@ def test_open_notebook(notebook, qtbot, tmpdir):
     # and the client has the correct name
     qtbot.waitUntil(lambda: text_present(nbwidget), timeout=NOTEBOOK_UP)
     assert text_present(nbwidget)
-    assert notebook.tabwidget.get_current_client().get_short_name() == "test"
+    assert notebook.tabwidget.currentWidget().get_short_name() == "test"
 
 
 @flaky(max_runs=3)
@@ -218,7 +218,7 @@ def test_save_notebook(notebook, qtbot, tmpdir):
     qtbot.waitUntil(lambda: text_present(nbwidget, text="test"),
                     timeout=NOTEBOOK_UP)
     assert text_present(nbwidget, text="test")
-    assert notebook.tabwidget.get_current_client().get_short_name() == "save"
+    assert notebook.tabwidget.currentWidget().get_short_name() == "save"
 
 
 def test_save_notebook_as_with_error(mocker, notebook, qtbot, tmpdir):
@@ -265,7 +265,7 @@ def test_open_console_when_no_kernel(notebook, qtbot, mocker):
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Shut the kernel down and check that this is successful
-    client = notebook.tabwidget.get_current_client()
+    client = notebook.tabwidget.currentWidget()
     kernel_id = client.get_kernel_id()
     sessions_url = client.get_session_url()
     client.shutdown_kernel()

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -157,7 +157,7 @@ def test_close_nonexisting_notebook(notebook, qtbot):
     notebook.close_client()
 
     # Assert tab is closed (without raising an exception)
-    assert client not in notebook.clients
+    assert client not in notebook.tabwidget.clients
 
 
 @flaky(max_runs=3)
@@ -249,7 +249,7 @@ def test_new_notebook(notebook, qtbot):
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Assert that we have one notebook and the welcome page
-    assert len(notebook.clients) == 2
+    assert len(notebook.tabwidget.clients) == 2
 
 
 def test_open_console_when_no_kernel(notebook, qtbot, mocker):

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -159,7 +159,8 @@ def test_close_nonexisting_notebook(notebook, qtbot):
     notebook.tabwidget.close_client()
 
     # Assert tab is closed (without raising an exception)
-    assert client not in notebook.tabwidget.clients
+    for client_index in range(notebook.tabwidget.count()):
+        assert client != notebook.tabwidget.widget(client_index)
 
 
 @flaky(max_runs=3)
@@ -251,7 +252,7 @@ def test_new_notebook(notebook, qtbot):
     qtbot.waitUntil(lambda: prompt_present(nbwidget), timeout=NOTEBOOK_UP)
 
     # Assert that we have one notebook and the welcome page
-    assert len(notebook.tabwidget.clients) == 2
+    assert notebook.tabwidget.count() == 2
 
 
 def test_open_console_when_no_kernel(notebook, qtbot, mocker):

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -26,10 +26,6 @@ from spyder.config.base import get_home_dir
 # Local imports
 from spyder_notebook.notebookplugin import NotebookPlugin
 
-# Python 2 compatibility
-if sys.version_info[0] == 2:
-    PermissionError = OSError
-
 # =============================================================================
 # Constants
 # =============================================================================

--- a/spyder_notebook/utils/nbopen.py
+++ b/spyder_notebook/utils/nbopen.py
@@ -21,14 +21,8 @@ import psutil
 from spyder.config.base import DEV, get_home_dir, get_module_path
 
 
-try:
-    # Spyder 4
-    from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
-    KERNELSPEC = ('spyder.plugins.ipythonconsole.utils'
-                  '.kernelspec.SpyderKernelSpec')
-except ImportError:
-    # Spyder 3
-    KERNELSPEC = 'spyder.utils.ipython.kernelspec.SpyderKernelSpec'
+# Kernel specification to use in notebook server
+KERNELSPEC = 'spyder.plugins.ipythonconsole.utils.kernelspec.SpyderKernelSpec'
 
 
 class NBServerError(Exception):

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -51,9 +51,25 @@ class NotebookAppMainWindow(QMainWindow):
         new_action.triggered.connect(self.tabwidget.create_new_client)
         file_menu.addAction(new_action)
 
-        open_action = QAction('Open Notebook', self)
+        open_action = QAction('Open Notebook...', self)
         open_action.triggered.connect(self.tabwidget.open_notebook)
         file_menu.addAction(open_action)
+
+        save_action = QAction('Save Notebook', self)
+        save_action.triggered.connect(
+            lambda checked: self.tabwidget.save_notebook(
+                self.tabwidget.currentWidget()))
+        file_menu.addAction(save_action)
+
+        saveas_action = QAction('Save As...', self)
+        saveas_action.triggered.connect(self.tabwidget.save_as)
+        file_menu.addAction(saveas_action)
+
+        close_action = QAction('Close Notebook', self)
+        close_action.triggered.connect(
+            lambda checked: self.tabwidget.close_client(
+                self.tabwidget.currentIndex()))
+        file_menu.addAction(close_action)
 
 
 if __name__ == '__main__':

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -17,7 +17,7 @@ import sys
 # Qt import
 from qtpy.QtCore import QCoreApplication, Qt
 from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
-from qtpy.QtWidgets import QApplication, QMainWindow
+from qtpy.QtWidgets import QAction, QApplication, QMainWindow
 
 # Plugin imports
 from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
@@ -39,9 +39,21 @@ class NotebookAppMainWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
-        widget = NotebookTabWidget(self, None, None, None)
-        widget.maybe_create_welcome_client()
-        self.setCentralWidget(widget)
+        self.tabwidget = NotebookTabWidget(self, None, None, None)
+        self.tabwidget.maybe_create_welcome_client()
+        self.setCentralWidget(self.tabwidget)
+        self._setup_menu()
+
+    def _setup_menu(self):
+        file_menu = self.menuBar().addMenu('File')
+
+        new_action = QAction('New Notebook', self)
+        new_action.triggered.connect(self.tabwidget.create_new_client)
+        file_menu.addAction(new_action)
+
+        open_action = QAction('Open Notebook', self)
+        open_action.triggered.connect(self.tabwidget.open_notebook)
+        file_menu.addAction(open_action)
 
 
 if __name__ == '__main__':

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""
+Simple application for working with notebooks.
+
+This is a stand-alone application showing how spyder_notebook can be used
+outside Spyder. It is mainly meant for development and testing purposes,
+but it can also serve as an example.
+"""
+
+# Standard library imports
+import sys
+
+# Qt import
+from qtpy.QtCore import QCoreApplication, Qt
+from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
+from qtpy.QtWidgets import QApplication, QMainWindow
+
+# Plugin imports
+from spyder_notebook.widgets.client import NotebookClient
+from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
+
+
+def use_software_rendering():
+    """
+    Instruct Qt to use software rendering.
+
+    This is necessary for some buggy graphics drivers (e.g. nvidia).
+    This function should be run before the QApplication is created.
+    """
+    QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+    QQuickWindow.setSceneGraphBackend(QSGRendererInterface.Software)
+
+
+class NotebookAppMainWindow(QMainWindow):
+    """Main window for stand-alone notebook application."""
+
+    def __init__(self):
+        super().__init__()
+        widget = NotebookTabWidget(self, None, None, None)
+        client = NotebookClient(parent=self, filename='Google')
+        client.go_to('http://google.com')
+        widget.add_tab(client)
+        self.setCentralWidget(widget)
+
+
+if __name__ == '__main__':
+    use_software_rendering()
+    app = QApplication([])
+    window = NotebookAppMainWindow()
+    window.show()
+    sys.exit(app.exec_())

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -20,7 +20,6 @@ from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
 from qtpy.QtWidgets import QApplication, QMainWindow
 
 # Plugin imports
-from spyder_notebook.widgets.client import NotebookClient
 from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 
 
@@ -41,9 +40,7 @@ class NotebookAppMainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         widget = NotebookTabWidget(self, None, None, None)
-        client = NotebookClient(parent=self, filename='Google')
-        client.go_to('http://google.com')
-        widget.add_tab(client)
+        widget.maybe_create_welcome_client()
         self.setCentralWidget(widget)
 
 

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -50,8 +50,6 @@ class NotebookTabWidget(Tabs):
     ----------
     actions : list of (QAction or QMenu or None) or None
         Items to be added to the context menu.
-    clients : list of NotebookClient
-        List of notebook clients displayed in tabs in this widget.
     untitled_num : int
         Number used in file name of newly created notebooks.
     """
@@ -76,7 +74,6 @@ class NotebookTabWidget(Tabs):
         super().__init__(parent, actions, menu, corner_widgets)
 
         self.actions = actions
-        self.clients = []
         self.untitled_num = 0
 
         if not sys.platform == 'darwin':
@@ -218,8 +215,6 @@ class NotebookTabWidget(Tabs):
 
         # Note: notebook index may have changed after closing related widgets
         self.removeTab(self.indexOf(client))
-        self.clients.remove(client)
-
         self.maybe_create_welcome_client()
 
     def save_notebook(self, client):
@@ -317,7 +312,6 @@ class NotebookTabWidget(Tabs):
         widget : NotebookClient
             Notebook widget to display in new tab.
         """
-        self.clients.append(widget)
         index = self.addTab(widget, widget.get_short_name())
         self.setCurrentIndex(index)
         self.setTabToolTip(index, widget.get_filename())

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -258,17 +258,17 @@ class NotebookTabWidget(Tabs):
         answer = QMessageBox.question(
             self, _('Save changes'), text, buttons)
         if answer == QMessageBox.Yes:
-            self.save_as(close_after_save=False)
+            self.save_as(reopen_after_save=False)
 
-    def save_as(self, name=None, close_after_save=True):
+    def save_as(self, name=None, reopen_after_save=True):
         """
         Save current notebook under a different file name.
 
         First, save the notebook under the original file name. Then ask user
         for a new file name (if `name` is not set), and return if no new name
         is given. Then, read the contents of the notebook that was just saved
-        and write them under the new file name. Finally. close the original
-        tab (unless `close_after_save` is False) and open a new tab with the
+        and write them under the new file name. If `reopen_after_save` is
+        True, then close the original tab and open a new tab with the
         notebook loaded from the new file name.
 
         Parameters
@@ -276,9 +276,9 @@ class NotebookTabWidget(Tabs):
         name : str or None, optional
             File name under which the notebook is to be saved. The default is
             None, meaning that the user should be asked for the file name.
-        close_after_save : bool, optional
-            Whether to close the original tab after saving the notebook and
-            before opening it under the new name. The default is True.
+        reopen_after_save : bool, optional
+            Whether to close the original tab and re-open it under the new
+            file name after saving the notebook. The default is True.
         """
         current_client = self.currentWidget()
         current_client.save()
@@ -304,9 +304,9 @@ class NotebookTabWidget(Tabs):
                        .format(filename, str(error)))
                 QMessageBox.critical(self, _("File Error"), txt)
                 return
-            if close_after_save:
+            if reopen_after_save:
                 self.close_client(save_before_close=False)
-            self.create_new_client(filename=filename)
+                self.create_new_client(filename=filename)
 
     def add_tab(self, widget):
         """

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -6,19 +6,37 @@
 """File implementing NotebookTabWidget."""
 
 # Standard library imports
+import os
 import os.path as osp
+import subprocess
 import sys
 
+# Qt imports
+from qtpy.compat import getopenfilenames
+from qtpy.QtWidgets import QMessageBox
+
+# Third-party imports
+import nbformat
+
 # Spyder imports
+from spyder.config.base import _
+from spyder.utils.programs import get_temp_dir
 from spyder.widgets.tabs import Tabs
 
 # Local imports
+from spyder_notebook.utils.nbopen import nbopen, NBServerError
 from spyder_notebook.widgets.client import NotebookClient
 
+
+# Directory in which new notebooks are created
+NOTEBOOK_TMPDIR = osp.join(get_temp_dir(), 'notebooks')
 
 # Path to HTML file with welcome message
 PACKAGE_PATH = osp.join(osp.dirname(__file__), '..')
 WELCOME = osp.join(PACKAGE_PATH, 'utils', 'templates', 'welcome.html')
+
+# Filter to use in file dialogs
+FILES_FILTER = '{} (*.ipynb)'.format(_('Jupyter notebooks'))
 
 
 class NotebookTabWidget(Tabs):
@@ -30,10 +48,14 @@ class NotebookTabWidget(Tabs):
     Attributes
     ----------
     actions : list of (QAction or QMenu or None) or None
+        Items to be added to the context menu.
     clients : list of NotebookClient
+        List of notebook clients displayed in tabs in this widget.
+    untitled_num : int
+        Number used in file name of newly created notebooks.
     """
 
-    def __init__(self, parent, actions, menu, corner_widgets):
+    def __init__(self, parent, actions, menu, corner_widgets, testing=False):
         """
         Constructor.
 
@@ -54,12 +76,87 @@ class NotebookTabWidget(Tabs):
 
         self.actions = actions
         self.clients = []
+        self.testing = testing
+        self.untitled_num = 0
 
         if not sys.platform == 'darwin':
             # Don't set document mode to true on OSX because it generates
             # a crash when the console is detached from the main window
             # Fixes spyder-ide/spyder#561
             self.setDocumentMode(True)
+
+    def open_notebook(self, filenames=None):
+        """
+        Open a notebook from file.
+
+        Parameters
+        ----------
+        filenames : list of str or None, optional
+            List of file names of notebooks to open. The default is None,
+            meaning that the user should be asked.
+        """
+        if not filenames:
+            filenames, _selfilter = getopenfilenames(
+                self, _('Open notebook'), '', FILES_FILTER)
+        if filenames:
+            for filename in filenames:
+                self.create_new_client(filename=filename)
+
+    def create_new_client(self, filename=None, give_focus=True):
+        """
+        Create a new notebook or load a pre-existing one.
+
+        Parameters
+        ----------
+        filename : str, optional
+            File name of the notebook to load in the new client. The default
+            is None, meaning that a new notebook should be created.
+        give_focus : bool, optional
+            Not used. The default is True.
+
+        Returns
+        -------
+        filename : str or None
+            File name of notebook that is opened, or None if unsuccessful.
+        """
+        # Generate the notebook name (in case of a new one)
+        if not filename:
+            if not osp.isdir(NOTEBOOK_TMPDIR):
+                os.makedirs(NOTEBOOK_TMPDIR)
+            nb_name = 'untitled' + str(self.untitled_num) + '.ipynb'
+            filename = osp.join(NOTEBOOK_TMPDIR, nb_name)
+            kernelspec = dict(display_name='Python 3 (Spyder)',
+                              name='python3')
+            metadata = dict(kernelspec=kernelspec)
+            nb_contents = nbformat.v4.new_notebook(metadata=metadata)
+            nbformat.write(nb_contents, filename)
+            self.untitled_num += 1
+
+        # Open the notebook with nbopen and get the url we need to render
+        try:
+            server_info = nbopen(filename)
+        except (subprocess.CalledProcessError, NBServerError):
+            QMessageBox.critical(
+                self,
+                _("Server error"),
+                _("The Jupyter Notebook server failed to start or it is "
+                  "taking too much time to do it. Please start it in a "
+                  "system terminal with the command 'jupyter notebook' to "
+                  "check for errors."))
+            # Create a welcome widget
+            # See issue 93
+            self.untitled_num -= 1
+            self.maybe_create_welcome_client()
+            return
+
+        welcome_client = self.maybe_create_welcome_client()
+        client = NotebookClient(self, filename, self.actions)
+        self.add_tab(client)
+        client.register(server_info)
+        client.load_notebook()
+        if welcome_client and not self.testing:
+            self.setCurrentIndex(0)
+        return filename
 
     def maybe_create_welcome_client(self):
         """

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -6,10 +6,19 @@
 """File implementing NotebookTabWidget."""
 
 # Standard library imports
+import os.path as osp
 import sys
 
 # Spyder imports
 from spyder.widgets.tabs import Tabs
+
+# Local imports
+from spyder_notebook.widgets.client import NotebookClient
+
+
+# Path to HTML file with welcome message
+PACKAGE_PATH = osp.join(osp.dirname(__file__), '..')
+WELCOME = osp.join(PACKAGE_PATH, 'utils', 'templates', 'welcome.html')
 
 
 class NotebookTabWidget(Tabs):
@@ -20,6 +29,7 @@ class NotebookTabWidget(Tabs):
 
     Attributes
     ----------
+    actions : list of (QAction or QMenu or None) or None
     clients : list of NotebookClient
     """
 
@@ -42,6 +52,7 @@ class NotebookTabWidget(Tabs):
         """
         super().__init__(parent, actions, menu, corner_widgets)
 
+        self.actions = actions
         self.clients = []
 
         if not sys.platform == 'darwin':
@@ -49,6 +60,22 @@ class NotebookTabWidget(Tabs):
             # a crash when the console is detached from the main window
             # Fixes spyder-ide/spyder#561
             self.setDocumentMode(True)
+
+    def maybe_create_welcome_client(self):
+        """
+        Create a welcome tab if there are no tabs.
+
+        Returns
+        -------
+        client : NotebookClient or None
+            The client in the created tab, or None if no tab is created.
+        """
+        if self.count() == 0:
+            welcome = open(WELCOME).read()
+            client = NotebookClient(
+                self, WELCOME, self.actions, ini_message=welcome)
+            self.add_tab(client)
+            return client
 
     def add_tab(self, widget):
         """

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -177,9 +177,9 @@ class NotebookTabWidget(Tabs):
             self.add_tab(client)
             return client
 
-    def close_client(self, index=None, client=None, save=False):
+    def close_client(self, index=None, save=False):
         """
-        Close client tab from index or widget (or close current tab).
+        Close client tab with given index (or close current tab).
 
         First save the note book (unless this is the welcome client or `save`
         is True). Then delete the note book if it is in `get_temp_dir()`.
@@ -190,22 +190,16 @@ class NotebookTabWidget(Tabs):
         ----------
         index : int or None, optional
             Index of tab to be closed. The default is None, meaning that the
-            value of `client` determines the tab to be closed.
-        client : NotebookClient or None, optional
-            Client of tab to be closed. The default is None, meaning that
-            the current tab is closed (assuming that `index` is also None).
+            current tab is closed.
         save : bool, optional
             The default is False, meaning that the notebook is saved before
             the tab is closed.
         """
         if not self.count():
             return
-        if client is not None:
-            index = self.indexOf(client)
-        if index is None and client is None:
+        if index is None:
             index = self.currentIndex()
-        if index is not None:
-            client = self.widget(index)
+        client = self.widget(index)
 
         is_welcome = client.get_filename() == WELCOME
         if not save and not is_welcome:

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -13,7 +13,15 @@ from spyder.widgets.tabs import Tabs
 
 
 class NotebookTabWidget(Tabs):
-    """Tabbed widget whose tabs display notebooks."""
+    """
+    Tabbed widget whose tabs display notebooks.
+
+    This is the main widget of the notebook plugin.
+
+    Attributes
+    ----------
+    clients : list of NotebookClient
+    """
 
     def __init__(self, parent, actions, menu, corner_widgets):
         """
@@ -33,6 +41,8 @@ class NotebookTabWidget(Tabs):
             the top left corner.
         """
         super().__init__(parent, actions, menu, corner_widgets)
+
+        self.clients = []
 
         if not sys.platform == 'darwin':
             # Don't set document mode to true on OSX because it generates

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -55,7 +55,7 @@ class NotebookTabWidget(Tabs):
         Number used in file name of newly created notebooks.
     """
 
-    def __init__(self, parent, actions, menu, corner_widgets, testing=False):
+    def __init__(self, parent, actions, menu, corner_widgets):
         """
         Constructor.
 
@@ -76,7 +76,6 @@ class NotebookTabWidget(Tabs):
 
         self.actions = actions
         self.clients = []
-        self.testing = testing
         self.untitled_num = 0
 
         if not sys.platform == 'darwin':
@@ -105,6 +104,9 @@ class NotebookTabWidget(Tabs):
     def create_new_client(self, filename=None):
         """
         Create a new notebook or load a pre-existing one.
+
+        This function also creates and selects a welcome tab, if no tabs are
+        present.
 
         Parameters
         ----------
@@ -152,7 +154,7 @@ class NotebookTabWidget(Tabs):
         self.add_tab(client)
         client.register(server_info)
         client.load_notebook()
-        if welcome_client and not self.testing:
+        if welcome_client:
             self.setCurrentIndex(0)
         return filename
 

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""File implementing NotebookTabWidget."""
+
+# Standard library imports
+import sys
+
+# Spyder imports
+from spyder.widgets.tabs import Tabs
+
+
+class NotebookTabWidget(Tabs):
+    """Tabbed widget whose tabs display notebooks."""
+
+    def __init__(self, parent, actions, menu, corner_widgets):
+        """
+        Constructor.
+
+        Parameters
+        ----------
+        parent : QWidget
+            Parent of the tabbed widget.
+        actions : list of (QAction or QMenu or None) or None
+            Items to be added to the context menu.
+        menu : QMenu or None
+            Context menu of the tabbed widget.
+        corner_widgets : dict of (Qt.Corner, list of QWidget or int) or None
+            Widgets to be placed in the top left and right corner of the
+            tabbed widget. A button for browsing the tabs is always added to
+            the top left corner.
+        """
+        super().__init__(parent, actions, menu, corner_widgets)
+
+        if not sys.platform == 'darwin':
+            # Don't set document mode to true on OSX because it generates
+            # a crash when the console is detached from the main window
+            # Fixes spyder-ide/spyder#561
+            self.setDocumentMode(True)

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -49,3 +49,17 @@ class NotebookTabWidget(Tabs):
             # a crash when the console is detached from the main window
             # Fixes spyder-ide/spyder#561
             self.setDocumentMode(True)
+
+    def add_tab(self, widget):
+        """
+        Add tab containing some notebook widget to the tabbed widget.
+
+        Parameters
+        ----------
+        widget : NotebookClient
+            Notebook widget to display in new tab.
+        """
+        self.clients.append(widget)
+        index = self.addTab(widget, widget.get_short_name())
+        self.setCurrentIndex(index)
+        self.setTabToolTip(index, widget.get_filename())

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -286,7 +286,7 @@ class NotebookTabWidget(Tabs):
             The default is False, meaning that the tab should be closed
             after saving the notebook.
         """
-        current_client = self.get_current_client()
+        current_client = self.currentWidget()
         current_client.save()
         original_path = current_client.get_filename()
         if not name:
@@ -327,18 +327,3 @@ class NotebookTabWidget(Tabs):
         index = self.addTab(widget, widget.get_short_name())
         self.setCurrentIndex(index)
         self.setTabToolTip(index, widget.get_filename())
-
-    def get_current_client(self):
-        """
-        Return the currently selected notebook.
-
-        Returns
-        -------
-        client : NotebookClient
-        """
-        try:
-            client = self.currentWidget()
-        except AttributeError:
-            client = None
-        if client is not None:
-            return client

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -102,7 +102,7 @@ class NotebookTabWidget(Tabs):
             for filename in filenames:
                 self.create_new_client(filename=filename)
 
-    def create_new_client(self, filename=None, give_focus=True):
+    def create_new_client(self, filename=None):
         """
         Create a new notebook or load a pre-existing one.
 
@@ -111,8 +111,6 @@ class NotebookTabWidget(Tabs):
         filename : str, optional
             File name of the notebook to load in the new client. The default
             is None, meaning that a new notebook should be created.
-        give_focus : bool, optional
-            Not used. The default is True.
 
         Returns
         -------

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -177,23 +177,23 @@ class NotebookTabWidget(Tabs):
             self.add_tab(client)
             return client
 
-    def close_client(self, index=None, save=False):
+    def close_client(self, index=None, save_before_close=True):
         """
         Close client tab with given index (or close current tab).
 
-        First save the note book (unless this is the welcome client or `save`
-        is True). Then delete the note book if it is in `get_temp_dir()`.
-        Then shutdown the kernel of the notebook and close the tab. Finally,
-        create a welcome tab if there are no tabs.
+        First save the notebook (unless this is the welcome client or
+        `save_before_close` is False). Then delete the notebook if it is in
+        `get_temp_dir()`. Then shutdown the kernel of the notebook and close
+        the tab. Finally, create a welcome tab if there are no tabs.
 
         Parameters
         ----------
         index : int or None, optional
             Index of tab to be closed. The default is None, meaning that the
             current tab is closed.
-        save : bool, optional
-            The default is False, meaning that the notebook is saved before
-            the tab is closed.
+        save_before_close : bool, optional
+            Whether to save the notebook before closing the tab. The default
+            is True.
         """
         if not self.count():
             return
@@ -202,7 +202,7 @@ class NotebookTabWidget(Tabs):
         client = self.widget(index)
 
         is_welcome = client.get_filename() == WELCOME
-        if not save and not is_welcome:
+        if save_before_close and not is_welcome:
             self.save_notebook(client)
         if not is_welcome:
             client.shutdown_kernel()
@@ -258,27 +258,27 @@ class NotebookTabWidget(Tabs):
         answer = QMessageBox.question(
             self, _('Save changes'), text, buttons)
         if answer == QMessageBox.Yes:
-            self.save_as(close=True)
+            self.save_as(close_after_save=False)
 
-    def save_as(self, name=None, close=False):
+    def save_as(self, name=None, close_after_save=True):
         """
         Save current notebook under a different file name.
 
-        First, save the note book under the original file name. Then ask user
+        First, save the notebook under the original file name. Then ask user
         for a new file name (if `name` is not set), and return if no new name
-        is given. Then, read the contents of the note book that was just saved
+        is given. Then, read the contents of the notebook that was just saved
         and write them under the new file name. Finally. close the original
-        tab (unless `close` is True) and open a new tab with the note book
-        loaded from the new file name.
+        tab (unless `close_after_save` is False) and open a new tab with the
+        notebook loaded from the new file name.
 
         Parameters
         ----------
         name : str or None, optional
             File name under which the notebook is to be saved. The default is
             None, meaning that the user should be asked for the file name.
-        close : bool
-            The default is False, meaning that the tab should be closed
-            after saving the notebook.
+        close_after_save : bool, optional
+            Whether to close the original tab after saving the notebook and
+            before opening it under the new name. The default is True.
         """
         current_client = self.currentWidget()
         current_client.save()
@@ -304,8 +304,8 @@ class NotebookTabWidget(Tabs):
                        .format(filename, str(error)))
                 QMessageBox.critical(self, _("File Error"), txt)
                 return
-            if not close:
-                self.close_client(save=True)
+            if close_after_save:
+                self.close_client(save_before_close=False)
             self.create_new_client(filename=filename)
 
     def add_tab(self, widget):


### PR DESCRIPTION
This PR splits the NotebookPlugin class in two parts: one part which handles the tabbed widget and one part responsible for integrating it into Spyder. There should not be any user visible changes.

I used the occasion to do some general clean up, including:
* Remove some functions that are not used.
* Remove some convenience functions that were only used in the tests.
* Add doc strings.
* Remove code specific to Python 2 or Spyder 3.
* Add a stand-alone app that can be used to view and edit notebooks.

Fixes #275