### PR TITLE
PR: Shutdown notebook server properly

### DIFF
--- a/spyder_notebook/utils/nbopen.py
+++ b/spyder_notebook/utils/nbopen.py
@@ -9,6 +9,7 @@
 """Open notebooks using the best available server."""
 
 import atexit
+import logging
 import os
 import os.path as osp
 import subprocess
@@ -23,6 +24,8 @@ from spyder.config.base import DEV, get_home_dir, get_module_path
 
 # Kernel specification to use in notebook server
 KERNELSPEC = 'spyder.plugins.ipythonconsole.utils.kernelspec.SpyderKernelSpec'
+
+logger = logging.getLogger(__name__)
 
 
 class NBServerError(Exception):
@@ -50,7 +53,8 @@ def nbopen(filename):
     server_info = find_best_server(filename)
 
     if server_info is not None:
-        print("Using existing server at", server_info['notebook_dir'])
+        logger.debug('Using existing server at %s',
+                     server_info['notebook_dir'])
         return server_info
     else:
         if filename.startswith(home_dir):
@@ -58,7 +62,7 @@ def nbopen(filename):
         else:
             nbdir = osp.dirname(filename)
 
-        print("Starting new server")
+        logger.debug("Starting new server")
         serverscript = osp.join(osp.dirname(__file__), '../server/main.py')
         command = [sys.executable, serverscript, '--no-browser',
                    '--notebook-dir={}'.format(nbdir),

--- a/spyder_notebook/utils/tests/test_nbopen.py
+++ b/spyder_notebook/utils/tests/test_nbopen.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""Tests for nbopen.py"""
+
+# Local imports
+from spyder_notebook.utils.nbopen import nbopen
+
+
+def test_nbopen_with_no_running_servers(mocker, tmpdir):
+    """Test that if nbopen is called when no servers are running, this calls
+    Popen (to start the server) and atexit.register to register the shutdown
+    function."""
+    filename = str(tmpdir + 'ham.ipynb')
+    serverinfo = {'notebook_dir': str(tmpdir)}
+    mock_lrs = mocker.Mock(side_effect=[[], [serverinfo]])
+    mock_shutdown = mocker.Mock()
+    mocker.patch(
+        'spyder_notebook.utils.nbopen.notebookapp',
+        list_running_servers=mock_lrs,
+        shutdown_server=mock_shutdown)
+    mock_Popen = mocker.patch('spyder_notebook.utils.nbopen.subprocess.Popen')
+    mock_register = mocker.patch(
+        'spyder_notebook.utils.nbopen.atexit.register')
+
+    res = nbopen(filename)
+
+    assert res == serverinfo
+    mock_Popen.assert_called_once()
+    mock_register.assert_called_once()
+    args, kwargs = mock_register.call_args
+    assert args == (mock_shutdown, serverinfo)

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -12,6 +12,7 @@ but it can also serve as an example.
 """
 
 # Standard library imports
+import logging
 import sys
 
 # Qt import
@@ -74,6 +75,7 @@ class NotebookAppMainWindow(QMainWindow):
 
 if __name__ == '__main__':
     use_software_rendering()
+    logging.basicConfig(level=logging.DEBUG)
     app = QApplication([])
     window = NotebookAppMainWindow()
     window.show()


### PR DESCRIPTION
Currently, all notebook servers are killed. This PR uses the `shutdown_server()` function instead, which is gentler (though I am not sure it makes a difference).

Additionally, the PR converts `print()` to debug calls of the `logging` module and adds an (incomplete) test for `nbopen()`.

Fixes #171.