### PR TITLE
PR: Restore notebooks that were open at end of last session

### DIFF
--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -19,7 +19,6 @@ from qtpy.QtWidgets import QMessageBox, QVBoxLayout, QMenu
 from spyder.api.plugins import SpyderPluginWidget
 from spyder.config.base import _
 from spyder.utils import icon_manager as ima
-from spyder.utils.programs import get_temp_dir
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
                                     add_actions, MENU_SEPARATOR)
 from spyder.utils.switcher import shorten_paths
@@ -29,7 +28,6 @@ from spyder.utils.switcher import shorten_paths
 from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 
 
-NOTEBOOK_TMPDIR = osp.join(get_temp_dir(), 'notebooks')
 FILTER_TITLE = _("Jupyter notebooks")
 FILES_FILTER = "{} (*.ipynb)".format(FILTER_TITLE)
 PACKAGE_PATH = osp.dirname(__file__)
@@ -250,8 +248,7 @@ class NotebookPlugin(SpyderPluginWidget):
                             self.main.get_spyder_pythonpath())
 
         client = self.tabwidget.create_new_client(filename)
-        filename = client.filename
-        if NOTEBOOK_TMPDIR not in filename:
+        if not self.tabwidget.is_newly_created(client):
             self.add_to_recent(filename)
             self.setup_menu_actions()
 

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -160,7 +160,9 @@ class NotebookPlugin(SpyderPluginWidget):
         super().register_plugin()
         self.focus_changed.connect(self.main.plugin_focus_changed)
         self.ipyconsole = self.main.ipyconsole
+        self.tabwidget.maybe_create_welcome_client()
         self.create_new_client()
+        self.tabwidget.setCurrentIndex(0)  # bring welcome tab to top
 
         # Connect to switcher
         self.switcher = self.main.switcher

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -247,7 +247,8 @@ class NotebookPlugin(SpyderPluginWidget):
             self.set_option('main/spyder_pythonpath',
                             self.main.get_spyder_pythonpath())
 
-        filename = self.tabwidget.create_new_client(filename)
+        client = self.tabwidget.create_new_client(filename)
+        filename = client.filename
         if NOTEBOOK_TMPDIR not in filename:
             self.add_to_recent(filename)
             self.setup_menu_actions()

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -31,7 +31,6 @@ from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 FILTER_TITLE = _("Jupyter notebooks")
 FILES_FILTER = "{} (*.ipynb)".format(FILTER_TITLE)
 PACKAGE_PATH = osp.dirname(__file__)
-WELCOME = osp.join(PACKAGE_PATH, 'utils', 'templates', 'welcome.html')
 
 
 class NotebookPlugin(SpyderPluginWidget):
@@ -216,13 +215,12 @@ class NotebookPlugin(SpyderPluginWidget):
             client = self.tabwidget.currentWidget()
         except AttributeError:  # tabwidget is not yet constructed
             client = None
-        if client:
-            if client.get_filename() != WELCOME:
-                self.save_as_action.setEnabled(True)
-                self.open_console_action.setEnabled(True)
-                return
-        self.save_as_action.setEnabled(False)
-        self.open_console_action.setEnabled(False)
+        if client and not self.tabwidget.is_welcome_client(client):
+            self.save_as_action.setEnabled(True)
+            self.open_console_action.setEnabled(True)
+        else:
+            self.save_as_action.setEnabled(False)
+            self.open_console_action.setEnabled(False)
 
     def add_to_recent(self, notebook):
         """

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -172,9 +172,15 @@ class NotebookPlugin(SpyderPluginWidget):
         super().register_plugin()
         self.focus_changed.connect(self.main.plugin_focus_changed)
         self.ipyconsole = self.main.ipyconsole
-        self.tabwidget.maybe_create_welcome_client()
-        self.create_new_client()
-        self.tabwidget.setCurrentIndex(0)  # bring welcome tab to top
+
+        # Open initial tabs
+        filenames = self.get_option('opened_notebooks')
+        if filenames:
+            self.open_notebook(filenames)
+        else:
+            self.tabwidget.maybe_create_welcome_client()
+            self.create_new_client()
+            self.tabwidget.setCurrentIndex(0)  # bring welcome tab to top
 
         # Connect to switcher
         self.switcher = self.main.switcher

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -260,7 +260,10 @@ class NotebookPlugin(SpyderPluginWidget):
             self.set_option('main/spyder_pythonpath',
                             self.main.get_spyder_pythonpath())
 
-        self.tabwidget.open_notebook(filenames)
+        filenames = self.tabwidget.open_notebook(filenames)
+        for filename in filenames:
+            self.add_to_recent(filename)
+        self.setup_menu_actions()
 
     def save_as(self):
         """Save current notebook to different file."""

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -107,7 +107,8 @@ def plugin_no_server(mocker, qtbot):
     """Set up the Notebook plugin with a fake nbopen which does not start
     a notebook server."""
     def fake_nbopen(filename):
-        return collections.defaultdict(str, filename=filename)
+        return collections.defaultdict(
+            str, filename=filename, notebook_dir=osp.dirname(filename))
     mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',
                  fake_nbopen)
     plugin = NotebookPlugin(None, testing=True)

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -12,7 +12,6 @@ import os
 import os.path as osp
 import shutil
 import sys
-import tempfile
 
 # Third-party library imports
 from flaky import flaky
@@ -21,7 +20,6 @@ import requests
 from qtpy.QtWebEngineWidgets import WEBENGINE
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QFileDialog, QApplication, QLineEdit
-from spyder.config.base import get_home_dir
 
 # Local imports
 from spyder_notebook.notebookplugin import NotebookPlugin
@@ -98,8 +96,8 @@ def notebook(qtbot):
     notebook. The latter tab is selected."""
     notebook_plugin = NotebookPlugin(None, testing=True)
     qtbot.addWidget(notebook_plugin)
+    notebook_plugin.tabwidget.maybe_create_welcome_client()
     notebook_plugin.create_new_client()
-    notebook_plugin.tabwidget.setCurrentIndex(1)
     return notebook_plugin
 
 

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -102,6 +102,19 @@ def notebook(qtbot):
     return notebook_plugin
 
 
+@pytest.fixture
+def plugin_no_server(mocker, qtbot):
+    """Set up the Notebook plugin with a fake nbopen which does not start
+    a notebook server."""
+    def fake_nbopen(filename):
+        return collections.defaultdict(str, filename=filename)
+    mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',
+                 fake_nbopen)
+    plugin = NotebookPlugin(None, testing=True)
+    qtbot.addWidget(plugin)
+    mocker.patch.object(plugin, 'main')
+    return plugin
+
 # =============================================================================
 # Tests
 # =============================================================================
@@ -279,15 +292,41 @@ def test_open_console_when_no_kernel(notebook, qtbot, mocker):
     notebook.ipyconsole._create_client_for_kernel.assert_not_called()
 
 
-def test_closing_plugin(mocker, qtbot):
+def test_register_plugin_with_opened_notebooks(mocker, plugin_no_server):
+    """Run .register_plugin() with the `opened_notebooks` conf option set to
+    a non-empty list. Check that plugin opens those notebooks."""
+    plugin = plugin_no_server
+    plugin.set_option('opened_notebooks', ['ham.ipynb', 'spam.ipynb'])
+
+    plugin.register_plugin()
+
+    tabwidget = plugin.tabwidget
+    assert tabwidget.count() == 2
+    assert tabwidget.widget(0).filename == 'ham.ipynb'
+    assert tabwidget.widget(1).filename == 'spam.ipynb'
+
+
+def test_register_plugin_with_opened_notebooks_empty(mocker, plugin_no_server):
+    """Run .register_plugin() with the `opened_notebooks` conf option set to
+    an empty list. Check that plugin opens a welcome tab and a new notebook,
+    and that the welcome tab is on top."""
+    plugin = plugin_no_server
+    plugin.set_option('opened_notebooks', [])
+
+    plugin.register_plugin()
+
+    tabwidget = plugin.tabwidget
+    assert tabwidget.count() == 2
+    assert tabwidget.is_welcome_client(tabwidget.widget(0))
+    assert tabwidget.is_newly_created(tabwidget.widget(1))
+    assert tabwidget.currentIndex() == 0
+
+
+def test_closing_plugin(mocker, plugin_no_server):
     """Close a plugin with a welcome tab, a new notebooks and a notebook
     opened from a file. Check that config variables `recent_notebooks` and
     `opened_notebook` are correctly set."""
-    def fake_nbopen(filename):
-        return collections.defaultdict(str, filename=filename)
-    mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',
-                 fake_nbopen)
-    plugin = NotebookPlugin(None, testing=True)
+    plugin = plugin_no_server
     mock_set_option = mocker.patch.object(plugin, 'set_option')
     plugin.tabwidget.maybe_create_welcome_client()
     plugin.create_new_client()

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -40,7 +40,7 @@ class NotebookAppMainWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
-        self.tabwidget = NotebookTabWidget(self, None, None, None)
+        self.tabwidget = NotebookTabWidget(self)
         self.tabwidget.maybe_create_welcome_client()
         self.setCentralWidget(self.tabwidget)
         self._setup_menu()

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -105,9 +105,6 @@ class NotebookTabWidget(Tabs):
         """
         Create a new notebook or load a pre-existing one.
 
-        This function also creates and selects a welcome tab, if no tabs are
-        present.
-
         Parameters
         ----------
         filename : str, optional
@@ -149,13 +146,10 @@ class NotebookTabWidget(Tabs):
             self.maybe_create_welcome_client()
             return None
 
-        welcome_client = self.maybe_create_welcome_client()
         client = NotebookClient(self, filename, self.actions)
         self.add_tab(client)
         client.register(server_info)
         client.load_notebook()
-        if welcome_client:
-            self.setCurrentIndex(0)
         return client
 
     def maybe_create_welcome_client(self):

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -198,10 +198,9 @@ class NotebookTabWidget(Tabs):
             index = self.currentIndex()
         client = self.widget(index)
 
-        is_welcome = client.get_filename() == WELCOME
-        if save_before_close and not is_welcome:
-            self.save_notebook(client)
-        if not is_welcome:
+        if not self.is_welcome_client(client):
+            if save_before_close:
+                self.save_notebook(client)
             client.shutdown_kernel()
         client.close()
 
@@ -320,6 +319,22 @@ class NotebookTabWidget(Tabs):
         path = client.get_filename()
         dirname, basename = osp.split(path)
         return dirname == NOTEBOOK_TMPDIR and basename.startswith('untitled')
+
+    @staticmethod
+    def is_welcome_client(client):
+        """
+        Return whether some client is a newly created notebook.
+
+        Parameters
+        ----------
+        client : NotebookClient
+            Client under consideration.
+
+        Returns
+        -------
+        True if `client` is a welcome client, False otherwise.
+        """
+        return client.get_filename() == WELCOME
 
     def add_tab(self, widget):
         """

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -54,7 +54,7 @@ class NotebookTabWidget(Tabs):
         Number used in file name of newly created notebooks.
     """
 
-    def __init__(self, parent, actions, menu, corner_widgets):
+    def __init__(self, parent, actions=None, menu=None, corner_widgets=None):
         """
         Constructor.
 

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -93,6 +93,11 @@ class NotebookTabWidget(Tabs):
         filenames : list of str or None, optional
             List of file names of notebooks to open. The default is None,
             meaning that the user should be asked.
+
+        Returns
+        -------
+        filenames : list of str
+            List of file names of notebooks that were opened.
         """
         if not filenames:
             filenames, _selfilter = getopenfilenames(
@@ -100,6 +105,7 @@ class NotebookTabWidget(Tabs):
         if filenames:
             for filename in filenames:
                 self.create_new_client(filename=filename)
+        return filenames
 
     def create_new_client(self, filename=None):
         """

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -116,8 +116,8 @@ class NotebookTabWidget(Tabs):
 
         Returns
         -------
-        filename : str or None
-            File name of notebook that is opened, or None if unsuccessful.
+        client : NotebookClient or None
+            Notebook client that is opened, or None if unsuccessful.
         """
         # Generate the notebook name (in case of a new one)
         if not filename:
@@ -147,7 +147,7 @@ class NotebookTabWidget(Tabs):
             # See issue 93
             self.untitled_num -= 1
             self.maybe_create_welcome_client()
-            return
+            return None
 
         welcome_client = self.maybe_create_welcome_client()
         client = NotebookClient(self, filename, self.actions)
@@ -156,7 +156,7 @@ class NotebookTabWidget(Tabs):
         client.load_notebook()
         if welcome_client:
             self.setCurrentIndex(0)
-        return filename
+        return client
 
     def maybe_create_welcome_client(self):
         """

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -42,3 +42,24 @@ def test_is_newly_created_with_welcome_tab(tabwidget):
     client."""
     client = tabwidget.maybe_create_welcome_client()
     assert not tabwidget.is_newly_created(client)
+
+
+def test_is_welcome_client_with_new_notebook(tabwidget):
+    """Test that .is_welcome_client() returns False if passed a client that is
+    indeed newly created."""
+    client = tabwidget.create_new_client()
+    assert not tabwidget.is_welcome_client(client)
+
+
+def test_is_welcome_client_with_opened_notebook(tabwidget):
+    """Test that .is_welcome_client() returns False if passed a client that
+    contains a notebook opened from a file."""
+    client = tabwidget.create_new_client('ham.ipynb')
+    assert not tabwidget.is_welcome_client(client)
+
+
+def test_is_welcome_client_with_welcome_tab(tabwidget):
+    """Test that .is_welcome_client() returns True if passed a welcome
+    client."""
+    client = tabwidget.maybe_create_welcome_client()
+    assert tabwidget.is_welcome_client(client)

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -1,0 +1,44 @@
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""Tests for notebooktabwidget.py."""
+
+# Standard library imports
+import collections
+
+# Third party imports
+import pytest
+
+# Local imports
+from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
+
+
+@pytest.fixture
+def tabwidget(mocker, qtbot):
+    """Create an empty NotebookTabWidget which does not start up servers."""
+    mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',
+                 return_value=collections.defaultdict(str))
+    widget = NotebookTabWidget(None)
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_is_newly_created_with_new_notebook(tabwidget):
+    """Test that .is_newly_created() returns True if passed a client that is
+    indeed newly created."""
+    client = tabwidget.create_new_client()
+    assert tabwidget.is_newly_created(client)
+
+
+def test_is_newly_created_with_opened_notebook(tabwidget):
+    """Test that .is_newly_created() returns False if passed a client that
+    contains a notebook opened from a file."""
+    client = tabwidget.create_new_client('ham.ipynb')
+    assert not tabwidget.is_newly_created(client)
+
+
+def test_is_newly_created_with_welcome_tab(tabwidget):
+    """Test that .is_newly_created() returns False if passed a welcome
+    client."""
+    client = tabwidget.maybe_create_welcome_client()
+    assert not tabwidget.is_newly_created(client)

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -5,6 +5,7 @@
 
 # Standard library imports
 import collections
+import os.path as osp
 
 # Third party imports
 import pytest
@@ -16,8 +17,11 @@ from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 @pytest.fixture
 def tabwidget(mocker, qtbot):
     """Create an empty NotebookTabWidget which does not start up servers."""
+    def fake_nbopen(filename):
+        return collections.defaultdict(
+            str, filename=filename, notebook_dir=osp.dirname(filename))
     mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',
-                 return_value=collections.defaultdict(str))
+                 fake_nbopen)
     widget = NotebookTabWidget(None)
     qtbot.addWidget(widget)
     return widget


### PR DESCRIPTION
This PR makes Spyder store the file names of the notebooks that were open at the end of a session when the plugin is closed. The next time Spyder opens, the plugin will open these notebooks again. As before, notebooks with names like `untitled0.ipynb` in the temporary directory are deleted, so these will not be opened at the start of the next session. If there are no notebooks to be opened at the start of a session, the plugin will open a newly created notebook and display the welcome tab.

This PR also adds some tests and convenience functions for identifying the welcome tab and untitled, newly created notebooks. 

Fixes #68.