### PR TITLE
PR: Implement dark theme

### DIFF
--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -18,6 +18,7 @@ from qtpy.QtWidgets import QMessageBox, QVBoxLayout, QMenu
 # Spyder imports
 from spyder.api.plugins import SpyderPluginWidget
 from spyder.config.base import _
+from spyder.config.gui import is_dark_interface
 from spyder.utils import icon_manager as ima
 from spyder.utils.qthelpers import (create_action, create_toolbutton,
                                     add_actions, MENU_SEPARATOR)
@@ -69,9 +70,10 @@ class NotebookPlugin(SpyderPluginWidget):
         menu_btn.setMenu(self._options_menu)
         menu_btn.setPopupMode(menu_btn.InstantPopup)
         corner_widgets = {Qt.TopRightCorner: [new_notebook_btn, menu_btn]}
+        dark_theme = is_dark_interface()
         self.tabwidget = NotebookTabWidget(
             self, menu=self._options_menu, actions=self.menu_actions,
-            corner_widgets=corner_widgets)
+            corner_widgets=corner_widgets, dark_theme=dark_theme)
 
         self.tabwidget.currentChanged.connect(self.refresh_plugin)
 

--- a/spyder_notebook/server/LICENSE
+++ b/spyder_notebook/server/LICENSE
@@ -5,6 +5,7 @@ https://github.com/jupyterlab/jupyterlab
 
 
 Copyright (c) 2015 Project Jupyter Contributors
+Copyright (c) 2020 Spyder Project Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/spyder_notebook/server/index.css
+++ b/spyder_notebook/server/index.css
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 body {
-  background: white;
+  background: var(--jp-layout-color1);
   margin: 0;
   padding: 0;
 }
@@ -18,10 +18,10 @@ body {
 }
 
 .jp-NotebookPanel {
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--jp-border-color1);
 }
 
 .notebookMenuBar {
-  border-bottom: 1px solid #bdbdbd;
+  border-bottom: 1px solid var(--jp-border-color0);
   min-height: 28px;
 }

--- a/spyder_notebook/server/index.css
+++ b/spyder_notebook/server/index.css
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
+| Copyright (c) Jupyter Development Team, Spyder Project Contributors.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 

--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -14,10 +14,16 @@ run ``python main.py``.
 import os
 from jinja2 import FileSystemLoader
 from notebook.base.handlers import IPythonHandler, FileFindHandler
-from notebook.notebookapp import NotebookApp
+from notebook.notebookapp import flags, NotebookApp
 from notebook.utils import url_path_join as ujoin
+from traitlets import Bool
 
 HERE = os.path.dirname(__file__)
+
+flags['dark'] = (
+    {'SpyderNotebookServer': {'dark_theme': True}},
+    'Use dark theme when rendering notebooks'
+)
 
 
 class NotebookHandler(IPythonHandler):
@@ -32,6 +38,7 @@ class NotebookHandler(IPythonHandler):
             # Use camelCase here, since that's what the lab components expect
             'baseUrl': self.base_url,
             'token': self.settings['token'],
+            'darkTheme': self.settings['dark_theme'],
             'notebookPath': filename,
             'frontendUrl': ujoin(self.base_url, 'static/'),
             # FIXME: Don't use a CDN here
@@ -54,9 +61,18 @@ class NotebookHandler(IPythonHandler):
 
 
 class SpyderNotebookServer(NotebookApp):
+    """Server rendering notebooks in HTML and serving them over HTTP."""
+
+    flags = flags
+
+    dark_theme = Bool(
+        False, config=True,
+        help='Whether to use dark theme when rendering notebooks')
+
     def init_webapp(self):
-        """initialize tornado webapp and httpserver.
-        """
+        """Initialize tornado webapp and httpserver."""
+        self.tornado_settings['dark_theme'] = self.dark_theme
+
         super().init_webapp()
 
         default_handlers = [

--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -1,16 +1,8 @@
-"""
-An example demonstrating a stand-alone "notebook".
+# Copyright (c) Jupyter Development Team, Spyder Project Contributors.
+# Distributed under the terms of the Modified BSD License.
 
-Copyright (c) Jupyter Development Team.
-Distributed under the terms of the Modified BSD License.
+"""Entry point for server rendering notebooks for Spyder."""
 
-Example
--------
-
-To run the example, see the instructions in the README to build it. Then
-run ``python main.py``.
-
-"""
 import os
 from jinja2 import FileSystemLoader
 from notebook.base.handlers import IPythonHandler, FileFindHandler

--- a/spyder_notebook/server/package.json
+++ b/spyder_notebook/server/package.json
@@ -18,6 +18,7 @@
     "@jupyterlab/rendermime": "^1.2.1",
     "@jupyterlab/services": "^4.2.0",
     "@jupyterlab/theme-light-extension": "^1.2.1",
+    "@jupyterlab/theme-dark-extension": "^1.2.1",
     "@phosphor/commands": "^1.7.0",
     "@phosphor/widgets": "^1.9.0",
     "es6-promise": "~4.2.6"

--- a/spyder_notebook/server/src/commands.ts
+++ b/spyder_notebook/server/src/commands.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team, Spyder Project Contributors.
+// Distributed under the terms of the Modified BSD License.
+
 /**
  * Set up keyboard shortcuts & commands for notebook
  */

--- a/spyder_notebook/server/src/index.ts
+++ b/spyder_notebook/server/src/index.ts
@@ -5,10 +5,19 @@ import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 // @ts-ignore
 __webpack_public_path__ = URLExt.join(PageConfig.getBaseUrl(), 'example/');
 
+// Stub for the require function.
+declare var require: any;
+
 import '@jupyterlab/application/style/index.css';
 import '@jupyterlab/codemirror/style/index.css';
 import '@jupyterlab/notebook/style/index.css';
-import '@jupyterlab/theme-light-extension/style/index.css';
+
+if (PageConfig.getOption('darkTheme') == 'true') {
+  require('@jupyterlab/theme-dark-extension/style/index.css');
+} else {
+  require('@jupyterlab/theme-light-extension/style/index.css');
+}
+
 import '../index.css';
 
 import { CommandRegistry } from '@phosphor/commands';
@@ -145,7 +154,6 @@ function createApp(manager: ServiceManager.IManager): void {
   window.addEventListener('resize', () => {
     panel.update();
   });
-
   SetupCommands(commands, menuBar, nbWidget, handler);
 }
 

--- a/spyder_notebook/server/src/index.ts
+++ b/spyder_notebook/server/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Jupyter Development Team.
+// Copyright (c) Jupyter Development Team, Spyder Project Contributors.
 // Distributed under the terms of the Modified BSD License.
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -106,7 +106,7 @@ def notebook(qtbot):
 def plugin_no_server(mocker, qtbot):
     """Set up the Notebook plugin with a fake nbopen which does not start
     a notebook server."""
-    def fake_nbopen(filename):
+    def fake_nbopen(filename, dark_theme):
         return collections.defaultdict(
             str, filename=filename, notebook_dir=osp.dirname(filename))
     mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',

--- a/spyder_notebook/utils/nbopen.py
+++ b/spyder_notebook/utils/nbopen.py
@@ -41,7 +41,7 @@ def find_best_server(filename):
         return None
 
 
-def nbopen(filename):
+def nbopen(filename, dark_theme=False):
     """
     Open a notebook using the best available server.
 
@@ -68,6 +68,8 @@ def nbopen(filename):
                    '--NotebookApp.password=',
                    "--KernelSpecManager.kernel_spec_class='{}'".format(
                            KERNELSPEC)]
+        if dark_theme:
+            command.append('--dark')
 
         if os.name == 'nt':
             creation_flag = 0x08000000  # CREATE_NO_WINDOW

--- a/spyder_notebook/utils/templates/welcome-dark.html
+++ b/spyder_notebook/utils/templates/welcome-dark.html
@@ -1,0 +1,640 @@
+
+<!DOCTYPE html>
+<HTML>
+<HEAD>
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<style>
+
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Raleway Light'), local('Raleway-Light'), url(http://fonts.gstatic.com/s/raleway/v9/-_Ctzj9b56b8RgXW8FArifk_vArhqVIZ0nv9q090hN8.woff2) format('woff2');
+}
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Raleway'), url(http://fonts.gstatic.com/s/raleway/v9/0dTEPzkLWceF7z0koJaX1A.woff2) format('woff2');
+}
+@font-face {
+  font-family: 'Raleway';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Raleway SemiBold'), local('Raleway-SemiBold'), url(http://fonts.gstatic.com/s/raleway/v9/xkvoNo9fC8O2RDydKj12b_k_vArhqVIZ0nv9q090hN8.woff2) format('woff2');
+}
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+body {
+  margin: 0;
+}
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+[hidden],
+template {
+  display: none;
+}
+a:active,
+a:hover {
+  outline: 0;
+}
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+b,
+strong {
+  font-weight: bold;
+}
+dfn {
+  font-style: italic;
+}
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+mark {
+  background: #ff0;
+  color: #000;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+img {
+  border: 0;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+figure {
+  margin: 1em 40px;
+}
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+pre {
+  overflow: auto;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+button {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+input {
+  line-height: normal;
+}
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
+}
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+textarea {
+  overflow: auto;
+}
+optgroup {
+  font-weight: bold;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td,
+th {
+  padding: 0;
+}
+
+
+/*
+* Skeleton V2.0.4
+* Copyright 2014, Dave Gamache
+* www.getskeleton.com
+* Free to use under the MIT license.
+* http://www.opensource.org/licenses/mit-license.php
+* 12/29/2014
+*/
+.container {
+  position: relative;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 20px;
+  box-sizing: border-box; }
+.column,
+.columns {
+  width: 100%;
+  float: left;
+  box-sizing: border-box; }
+@media (min-width: 400px) {
+  .container {
+    width: 85%;
+    padding: 0; }
+}
+@media (min-width: 550px) {
+  .container {
+    width: 80%; }
+  .column,
+  .columns {
+    margin-left: 4%; }
+  .column:first-child,
+  .columns:first-child {
+    margin-left: 0; }
+
+  .one.column,
+  .one.columns                    { width: 4.66666666667%; }
+  .two.columns                    { width: 13.3333333333%; }
+  .three.columns                  { width: 22%;            }
+  .four.columns                   { width: 30.6666666667%; }
+  .five.columns                   { width: 39.3333333333%; }
+  .six.columns                    { width: 48%;            }
+  .seven.columns                  { width: 56.6666666667%; }
+  .eight.columns                  { width: 65.3333333333%; }
+  .nine.columns                   { width: 74.0%;          }
+  .ten.columns                    { width: 82.6666666667%; }
+  .eleven.columns                 { width: 91.3333333333%; }
+  .twelve.columns                 { width: 100%; margin-left: 0; }
+
+  .one-third.column               { width: 30.6666666667%; }
+  .two-thirds.column              { width: 65.3333333333%; }
+
+  .one-half.column                { width: 48%; }
+
+  /* Offsets */
+  .offset-by-one.column,
+  .offset-by-one.columns          { margin-left: 8.66666666667%; }
+  .offset-by-two.column,
+  .offset-by-two.columns          { margin-left: 17.3333333333%; }
+  .offset-by-three.column,
+  .offset-by-three.columns        { margin-left: 26%;            }
+  .offset-by-four.column,
+  .offset-by-four.columns         { margin-left: 34.6666666667%; }
+  .offset-by-five.column,
+  .offset-by-five.columns         { margin-left: 43.3333333333%; }
+  .offset-by-six.column,
+  .offset-by-six.columns          { margin-left: 52%;            }
+  .offset-by-seven.column,
+  .offset-by-seven.columns        { margin-left: 60.6666666667%; }
+  .offset-by-eight.column,
+  .offset-by-eight.columns        { margin-left: 69.3333333333%; }
+  .offset-by-nine.column,
+  .offset-by-nine.columns         { margin-left: 78.0%;          }
+  .offset-by-ten.column,
+  .offset-by-ten.columns          { margin-left: 86.6666666667%; }
+  .offset-by-eleven.column,
+  .offset-by-eleven.columns       { margin-left: 95.3333333333%; }
+
+  .offset-by-one-third.column,
+  .offset-by-one-third.columns    { margin-left: 34.6666666667%; }
+  .offset-by-two-thirds.column,
+  .offset-by-two-thirds.columns   { margin-left: 69.3333333333%; }
+
+  .offset-by-one-half.column,
+  .offset-by-one-half.columns     { margin-left: 52%; }
+
+}
+html {
+  font-size: 62.5%; }
+body {
+  font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
+  line-height: 1.6;
+  font-weight: 400;
+  font-family: "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #222; }
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  font-weight: 300; }
+h1 { font-size: 3.6rem; line-height: 1.2;  letter-spacing: -.1rem;}
+h2 { font-size: 3.4rem; line-height: 1.25; letter-spacing: -.1rem; }
+h3 { font-size: 3.2rem; line-height: 1.3;  letter-spacing: -.1rem; }
+h4 { font-size: 2.8rem; line-height: 1.35; letter-spacing: -.08rem; }
+h5 { font-size: 2.4rem; line-height: 1.5;  letter-spacing: -.05rem; }
+h6 { font-size: 1.5rem; line-height: 1.6;  letter-spacing: 0; }
+
+p {
+  margin-top: 0; }
+a {
+  color: #1EAEDB; }
+a:hover {
+  color: #0FA0CE; }
+.button,
+button,
+input[type="submit"],
+input[type="reset"],
+input[type="button"] {
+  display: inline-block;
+  height: 38px;
+  padding: 0 30px;
+  color: #555;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 38px;
+  letter-spacing: .1rem;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: transparent;
+  border-radius: 4px;
+  border: 1px solid #bbb;
+  cursor: pointer;
+  box-sizing: border-box; }
+.button:hover,
+button:hover,
+input[type="submit"]:hover,
+input[type="reset"]:hover,
+input[type="button"]:hover,
+.button:focus,
+button:focus,
+input[type="submit"]:focus,
+input[type="reset"]:focus,
+input[type="button"]:focus {
+  color: #333;
+  border-color: #888;
+  outline: 0; }
+.button.button-primary,
+button.button-primary,
+input[type="submit"].button-primary,
+input[type="reset"].button-primary,
+input[type="button"].button-primary {
+  color: #FFF;
+  background-color: #33C3F0;
+  border-color: #33C3F0; }
+.button.button-primary:hover,
+button.button-primary:hover,
+input[type="submit"].button-primary:hover,
+input[type="reset"].button-primary:hover,
+input[type="button"].button-primary:hover,
+.button.button-primary:focus,
+button.button-primary:focus,
+input[type="submit"].button-primary:focus,
+input[type="reset"].button-primary:focus,
+input[type="button"].button-primary:focus {
+  color: #FFF;
+  background-color: #1EAEDB;
+  border-color: #1EAEDB; }
+input[type="email"],
+input[type="number"],
+input[type="search"],
+input[type="text"],
+input[type="tel"],
+input[type="url"],
+input[type="password"],
+textarea,
+select {
+  height: 38px;
+  padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
+  background-color: #fff;
+  border: 1px solid #D1D1D1;
+  border-radius: 4px;
+  box-shadow: none;
+  box-sizing: border-box; }
+/* Removes awkward default styles on some inputs for iOS */
+input[type="email"],
+input[type="number"],
+input[type="search"],
+input[type="text"],
+input[type="tel"],
+input[type="url"],
+input[type="password"],
+textarea {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none; }
+textarea {
+  min-height: 65px;
+  padding-top: 6px;
+  padding-bottom: 6px; }
+input[type="email"]:focus,
+input[type="number"]:focus,
+input[type="search"]:focus,
+input[type="text"]:focus,
+input[type="tel"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+textarea:focus,
+select:focus {
+  border: 1px solid #33C3F0;
+  outline: 0; }
+label,
+legend {
+  display: block;
+  margin-bottom: .5rem;
+  font-weight: 600; }
+fieldset {
+  padding: 0;
+  border-width: 0; }
+input[type="checkbox"],
+input[type="radio"] {
+  display: inline; }
+label > .label-body {
+  display: inline-block;
+  margin-left: .5rem;
+  font-weight: normal; }
+ul {
+  list-style: circle inside; }
+ol {
+  list-style: decimal inside; }
+ol, ul {
+  padding-left: 0;
+  margin-top: 0; }
+ul ul,
+ul ol,
+ol ol,
+ol ul {
+  margin: 1.5rem 0 1.5rem 3rem;
+  font-size: 90%; }
+li {
+  margin-bottom: 1rem; }
+th,
+td {
+  padding: 12px 15px;
+  text-align: left;
+  border-bottom: 1px solid #E1E1E1; }
+th:first-child,
+td:first-child {
+  padding-left: 0; }
+th:last-child,
+td:last-child {
+  padding-right: 0; }
+button,
+.button {
+  margin-bottom: 1rem; }
+input,
+textarea,
+select,
+fieldset {
+  margin-bottom: 1.5rem; }
+pre,
+blockquote,
+dl,
+figure,
+table,
+p,
+ul,
+ol,
+form {
+  margin-bottom: 2.5rem; }
+.u-full-width {
+  width: 100%;
+  box-sizing: border-box; }
+.u-max-full-width {
+  max-width: 100%;
+  box-sizing: border-box; }
+.u-pull-right {
+  float: right; }
+.u-pull-left {
+  float: left; }
+hr {
+  margin-top: 3rem;
+  margin-bottom: 3.5rem;
+  border-width: 0;
+  border-top: 1px solid #E1E1E1; }
+.container:after,
+.row:after,
+.u-cf {
+  content: "";
+  display: table;
+  clear: both; }
+
+pre {
+  display: block;
+  padding: 9.5px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #333;
+  word-break: break-all;
+  word-wrap: break-word;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px;
+}
+
+@media (min-width: 400px) {}
+@media (min-width: 550px) {}
+@media (min-width: 750px) {}
+@media (min-width: 1000px) {}
+@media (min-width: 1200px) {}
+
+</style>
+
+<style>
+.hll { background-color: #ffffcc }
+.c { color: #408080; font-style: italic } /* Comment */
+.err { border: 1px solid #FF0000 } /* Error */
+.k { color: #008000; font-weight: bold } /* Keyword */
+.o { color: #666666 } /* Operator */
+.ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+.cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.cp { color: #BC7A00 } /* Comment.Preproc */
+.cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
+.c1 { color: #408080; font-style: italic } /* Comment.Single */
+.cs { color: #408080; font-style: italic } /* Comment.Special */
+.gd { color: #A00000 } /* Generic.Deleted */
+.ge { font-style: italic } /* Generic.Emph */
+.gr { color: #FF0000 } /* Generic.Error */
+.gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.gi { color: #00A000 } /* Generic.Inserted */
+.go { color: #888888 } /* Generic.Output */
+.gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.gs { font-weight: bold } /* Generic.Strong */
+.gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.gt { color: #0044DD } /* Generic.Traceback */
+.kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.kp { color: #008000 } /* Keyword.Pseudo */
+.kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.kt { color: #B00040 } /* Keyword.Type */
+.m { color: #666666 } /* Literal.Number */
+.s { color: #BA2121 } /* Literal.String */
+.na { color: #7D9029 } /* Name.Attribute */
+.nb { color: #008000 } /* Name.Builtin */
+.nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.no { color: #880000 } /* Name.Constant */
+.nd { color: #AA22FF } /* Name.Decorator */
+.ni { color: #999999; font-weight: bold } /* Name.Entity */
+.ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.nf { color: #0000FF } /* Name.Function */
+.nl { color: #A0A000 } /* Name.Label */
+.nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.nt { color: #008000; font-weight: bold } /* Name.Tag */
+.nv { color: #19177C } /* Name.Variable */
+.ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.w { color: #bbbbbb } /* Text.Whitespace */
+.mb { color: #666666 } /* Literal.Number.Bin */
+.mf { color: #666666 } /* Literal.Number.Float */
+.mh { color: #666666 } /* Literal.Number.Hex */
+.mi { color: #666666 } /* Literal.Number.Integer */
+.mo { color: #666666 } /* Literal.Number.Oct */
+.sa { color: #BA2121 } /* Literal.String.Affix */
+.sb { color: #BA2121 } /* Literal.String.Backtick */
+.sc { color: #BA2121 } /* Literal.String.Char */
+.dl { color: #BA2121 } /* Literal.String.Delimiter */
+.sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.s2 { color: #BA2121 } /* Literal.String.Double */
+.se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.sh { color: #BA2121 } /* Literal.String.Heredoc */
+.si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.sx { color: #008000 } /* Literal.String.Other */
+.sr { color: #BB6688 } /* Literal.String.Regex */
+.s1 { color: #BA2121 } /* Literal.String.Single */
+.ss { color: #19177C } /* Literal.String.Symbol */
+.bp { color: #008000 } /* Name.Builtin.Pseudo */
+.fm { color: #0000FF } /* Name.Function.Magic */
+.vc { color: #19177C } /* Name.Variable.Class */
+.vg { color: #19177C } /* Name.Variable.Global */
+.vi { color: #19177C } /* Name.Variable.Instance */
+.vm { color: #19177C } /* Name.Variable.Magic */
+.il { color: #666666 } /* Literal.Number.Integer.Long */
+</style>
+
+<style>
+h1.title {margin-top : 20px}
+img {max-width : 100%}
+</style>
+
+<style>
+body {
+  color: #fff; 
+  background-color: #19232d;
+}
+
+hr {
+  border-top: 1px solid #292d3e; 
+}
+</style>
+
+
+</HEAD>
+<BODY>
+    <div class ="container">
+        <div class = "row">
+            <div class = "col-md-12 twelve columns">
+<h1 id="section"></h1>
+<h1 id="welcome-to-the-notebook-plugin">Welcome to the Notebook plugin</h1>
+<h2 id="usage">Usage</h2>
+<p>With this plugin you can open, edit and create Jupyter notebooks.</p>
+<p>To create new notebooks, you can right-click and click in <em>Open new notebook</em>. You can also click the <span title="Open new notebook"><b>+</b></span> button.</p>
+<p>To open and save notebooks, please press the <span title="Options"><b>&#9881;</b></span> button to the right of this plugin.</p>
+
+    <HR/>
+            </div>
+        </div>
+    </div>
+  </BODY>
+</HTML>

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -12,10 +12,12 @@ but it can also serve as an example.
 """
 
 # Standard library imports
+import argparse
 import logging
 import sys
 
-# Qt import
+# Qt imports
+import qdarkstyle
 from qtpy.QtCore import QCoreApplication, Qt
 from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
 from qtpy.QtWidgets import QAction, QApplication, QMainWindow
@@ -38,8 +40,12 @@ def use_software_rendering():
 class NotebookAppMainWindow(QMainWindow):
     """Main window for stand-alone notebook application."""
 
-    def __init__(self):
+    def __init__(self, dark_theme=False):
         super().__init__()
+
+        if dark_theme:
+            self.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
+
         self.tabwidget = NotebookTabWidget(self)
         self.tabwidget.maybe_create_welcome_client()
         self.setCentralWidget(self.tabwidget)
@@ -73,10 +79,19 @@ class NotebookAppMainWindow(QMainWindow):
         file_menu.addAction(close_action)
 
 
-if __name__ == '__main__':
+def main():
+    """Execute example application."""
     use_software_rendering()
     logging.basicConfig(level=logging.DEBUG)
-    app = QApplication([])
-    window = NotebookAppMainWindow()
+    app = QApplication(sys.argv)
+    arguments = app.arguments()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dark', action='store_true')
+    result = parser.parse_args(arguments[1:])  # arguments[0] = program name
+    window = NotebookAppMainWindow(dark_theme=result.dark)
     window.show()
     sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -40,14 +40,19 @@ def use_software_rendering():
 class NotebookAppMainWindow(QMainWindow):
     """Main window for stand-alone notebook application."""
 
-    def __init__(self, dark_theme=False):
+    def __init__(self, options):
         super().__init__()
 
-        if dark_theme:
+        if options.dark:
             self.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
 
-        self.tabwidget = NotebookTabWidget(self, dark_theme=dark_theme)
-        self.tabwidget.maybe_create_welcome_client()
+        self.tabwidget = NotebookTabWidget(self, dark_theme=options.dark)
+
+        if options.notebook:
+            self.tabwidget.open_notebook(options.notebook)
+        else:
+            self.tabwidget.maybe_create_welcome_client()
+
         self.setCentralWidget(self.tabwidget)
         self._setup_menu()
 
@@ -86,9 +91,10 @@ def main():
     app = QApplication(sys.argv)
     arguments = app.arguments()
     parser = argparse.ArgumentParser()
+    parser.add_argument('notebook', nargs='*')
     parser.add_argument('--dark', action='store_true')
     result = parser.parse_args(arguments[1:])  # arguments[0] = program name
-    window = NotebookAppMainWindow(dark_theme=result.dark)
+    window = NotebookAppMainWindow(result)
     window.show()
     sys.exit(app.exec_())
 

--- a/spyder_notebook/widgets/example_app.py
+++ b/spyder_notebook/widgets/example_app.py
@@ -46,7 +46,7 @@ class NotebookAppMainWindow(QMainWindow):
         if dark_theme:
             self.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
 
-        self.tabwidget = NotebookTabWidget(self)
+        self.tabwidget = NotebookTabWidget(self, dark_theme=dark_theme)
         self.tabwidget.maybe_create_welcome_client()
         self.setCentralWidget(self.tabwidget)
         self._setup_menu()

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -143,7 +143,7 @@ class NotebookTabWidget(Tabs):
 
         # Open the notebook with nbopen and get the url we need to render
         try:
-            server_info = nbopen(filename)
+            server_info = nbopen(filename, self.dark_theme)
         except (subprocess.CalledProcessError, NBServerError):
             QMessageBox.critical(
                 self,

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -35,6 +35,8 @@ NOTEBOOK_TMPDIR = osp.join(get_temp_dir(), 'notebooks')
 # Path to HTML file with welcome message
 PACKAGE_PATH = osp.join(osp.dirname(__file__), '..')
 WELCOME = osp.join(PACKAGE_PATH, 'utils', 'templates', 'welcome.html')
+WELCOME_DARK = osp.join(PACKAGE_PATH, 'utils', 'templates',
+                        'welcome-dark.html')
 
 # Filter to use in file dialogs
 FILES_FILTER = '{} (*.ipynb)'.format(_('Jupyter notebooks'))
@@ -50,11 +52,14 @@ class NotebookTabWidget(Tabs):
     ----------
     actions : list of (QAction or QMenu or None) or None
         Items to be added to the context menu.
+    dark_theme : bool
+        Whether to display notebooks in a dark theme. The default is False.
     untitled_num : int
         Number used in file name of newly created notebooks.
     """
 
-    def __init__(self, parent, actions=None, menu=None, corner_widgets=None):
+    def __init__(self, parent, actions=None, menu=None, corner_widgets=None,
+                 dark_theme=False):
         """
         Constructor.
 
@@ -74,6 +79,7 @@ class NotebookTabWidget(Tabs):
         super().__init__(parent, actions, menu, corner_widgets)
 
         self.actions = actions
+        self.dark_theme = dark_theme
         self.untitled_num = 0
 
         if not sys.platform == 'darwin':
@@ -168,7 +174,10 @@ class NotebookTabWidget(Tabs):
             The client in the created tab, or None if no tab is created.
         """
         if self.count() == 0:
-            welcome = open(WELCOME).read()
+            if self.dark_theme:
+                welcome = open(WELCOME_DARK).read()
+            else:
+                welcome = open(WELCOME).read()
             client = NotebookClient(
                 self, WELCOME, self.actions, ini_message=welcome)
             self.add_tab(client)
@@ -352,7 +361,7 @@ class NotebookTabWidget(Tabs):
         -------
         True if `client` is a welcome client, False otherwise.
         """
-        return client.get_filename() == WELCOME
+        return client.get_filename() in [WELCOME, WELCOME_DARK]
 
     def add_tab(self, widget):
         """

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -17,7 +17,7 @@ from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
 @pytest.fixture
 def tabwidget(mocker, qtbot):
     """Create an empty NotebookTabWidget which does not start up servers."""
-    def fake_nbopen(filename):
+    def fake_nbopen(filename, dark_theme):
         return collections.defaultdict(
             str, filename=filename, notebook_dir=osp.dirname(filename))
     mocker.patch('spyder_notebook.widgets.notebooktabwidget.nbopen',


### PR DESCRIPTION
This PR renders notebooks using the JupyerLab dark theme if the Spyder interface is set to dark.

![Screenshot_20200622_180737](https://user-images.githubusercontent.com/7941918/85317078-b3fcf080-b4b5-11ea-8837-f2e76dda2059.png)

It was not such a big change in the end but I learned a lot about JupyterLab, TypeScript and webpack in the process. You will see that the colour scheme of the JupyterLab dark theme is a bit different from Spyder: the text of the notebook pane is whiter and the background is blacker than in the other panes.