### PR TITLE
PR: Remove quotes from command line when starting server

### DIFF
--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -186,7 +186,7 @@ class ServerManager(QObject):
         arguments = [serverscript, '--no-browser',
                      '--notebook-dir={}'.format(nbdir),
                      '--NotebookApp.password=',
-                     "--KernelSpecManager.kernel_spec_class='{}'".format(
+                     '--KernelSpecManager.kernel_spec_class={}'.format(
                            KERNELSPEC)]
         if self.dark_theme:
             arguments.append('--dark')


### PR DESCRIPTION
This PR fixes a compatibility issue with traitlets version 5. Older versions should still work.

Fixes #314