### PR TITLE
PR: Check status when retrieving sessions before parsing reply

### DIFF
--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -288,11 +288,10 @@ class NotebookClient(QWidget):
             QMessageBox.warning(self, _('Server error'), msg)
             return None
 
-        sessions = json.loads(sessions_response.content.decode())
         if sessions_response.status_code != requests.codes.ok:
             msg = _('Spyder could not get a list of sessions '
                     'from the Jupyter Notebook server. '
-                    'Message: {}').format(sessions.get('message'))
+                    'Status code: {}').format(sessions_response.status_code)
             QMessageBox.warning(self, _('Server error'), msg)
             return None
 
@@ -301,6 +300,7 @@ class NotebookClient(QWidget):
         else:
             path = self.path
 
+        sessions = json.loads(sessions_response.content.decode())
         for session in sessions:
             notebook_path = session.get('notebook', {}).get('path')
             if notebook_path is not None and notebook_path == path:

--- a/spyder_notebook/widgets/tests/test_client.py
+++ b/spyder_notebook/widgets/tests/test_client.py
@@ -63,9 +63,11 @@ def test_notebookclient_get_kernel_id_with_fields_missing(plugin, mocker):
 
 
 def test_notebookclient_get_kernel_id_with_error_status(plugin, mocker):
-    """Test NotebookClient.get_kernel_id() when response has error status."""
+    """Test NotebookClient.get_kernel_id() when response has error status.
+    In this case, the content of the response may be empty;
+    see spyder-ide/spyder-notebook#317."""
     response = mocker.Mock()
-    content = b'{"message": "error"}'
+    content = b''
     response.content = content
     response.status_code = requests.codes.forbidden
     mocker.patch('requests.get', return_value=response)


### PR DESCRIPTION
Having received the response from the server to our request to list all sessions, first check whether the status is ok and only if it is, parse the reply. Before (in code added in PR #232), this was done in the opposite order.

Update the test to ensure reply is not parsed if status is not ok.

Fixes #317.