### PR TITLE
PR: Allow user to config notebook theme

### DIFF
--- a/spyder_notebook/config.py
+++ b/spyder_notebook/config.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Spyder Project Contributors
+# Licensed under the terms of the MIT License
+
+"""Spyder configuration page for notebook plugin."""
+
+# Qt imports
+from qtpy.QtWidgets import QGridLayout, QGroupBox, QVBoxLayout
+
+# Spyder imports
+from spyder.api.preferences import PluginConfigPage
+
+# Local imports
+from spyder_notebook.utils.localization import _
+
+
+class NotebookConfigPage(PluginConfigPage):
+    """Widget with configuration options for notebook plugin."""
+
+    def setup_page(self):
+        """Fill configuration page with widgets."""
+        themes = ['Same as Spyder', 'Light', 'Dark']
+        theme_choices = list(zip(themes,
+                                 [theme.lower() for theme in themes]))
+        theme_combo = self.create_combobox(
+            _('Notebook theme'), theme_choices, 'theme', restart=True)
+
+        interface_layout = QGridLayout()
+        interface_layout.addWidget(theme_combo.label, 0, 0)
+        interface_layout.addWidget(theme_combo.combobox, 0, 1)
+        interface_group = QGroupBox(_('Interface'))
+        interface_group.setLayout(interface_layout)
+
+        vlayout = QVBoxLayout()
+        vlayout.addWidget(interface_group)
+        vlayout.addStretch(1)
+        self.setLayout(vlayout)

--- a/spyder_notebook/tests/test_config.py
+++ b/spyder_notebook/tests/test_config.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Project Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""Tests for config.py"""
+
+# Third-party library imports
+import pytest
+
+# Spyder imports
+from spyder.preferences.configdialog import ConfigDialog
+
+# Local imports
+from spyder_notebook.config import NotebookConfigPage
+from spyder_notebook.tests.test_plugin import plugin_no_server
+
+
+def test_config(mocker, plugin_no_server, qtbot):
+    """Test that config page can be created and shown."""
+    dlg = ConfigDialog()
+    page = NotebookConfigPage(plugin_no_server, parent=plugin_no_server)
+    page.initialize()
+    dlg.add_page(page)
+    dlg.show()
+    qtbot.addWidget(dlg)
+    # no assert, just check that the config page can be created
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -366,5 +366,19 @@ def test_view_server_info(mocker, plugin_no_server):
     mock_ServerInfoDialog.return_value.show.assert_called_once()
 
 
+@pytest.mark.parametrize('config_value', ['same as spyder', 'dark', 'light'])
+@pytest.mark.parametrize('spyder_is_dark', [True, False])
+def test_dark_theme(mocker, plugin_no_server, config_value, spyder_is_dark):
+    plugin_no_server.set_option('theme', config_value)
+    mocker.patch('spyder_notebook.notebookplugin.is_dark_interface',
+                 return_value=spyder_is_dark)
+
+    value = plugin_no_server.dark_theme
+
+    expected = (config_value == 'dark' or
+                (config_value == 'same as spyder' and spyder_is_dark))
+    assert value == expected
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Add a Notebook config page, with a combo box to set the notebook theme. There are three possibilities: Dark, Light, Same as Spyder (default). Set the notebook theme according to the user's preference. Also add some tests.

Fixes #310