### PR TITLE
PR: Update error message when server times out

### DIFF
--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -395,10 +395,9 @@ class NotebookTabWidget(Tabs):
         QMessageBox.critical(
             self,
             _("Server error"),
-            _("The Jupyter Notebook server failed to start or it is "
-              "taking too much time to do it. Please start it in a "
-              "system terminal with the command 'jupyter notebook' to "
-              "check for errors."))
+            _("The Spyder Notebook server failed to start or it is "
+              "taking too much time to do it. Please select 'Server info' "
+              "in the plugin's option menu to check for errors."))
         # Create a welcome widget
         # See issue 93
         self.untitled_num -= 1


### PR DESCRIPTION
We no longer use `jupyter notebook` but added a menu item to check the output of the server process, so refer to that.

Fixes #337.