### PR TITLE
PR: Wait a bit repeatedly after save before reading notebook

### DIFF
--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -40,6 +40,12 @@ WELCOME_DARK = osp.join(PACKAGE_PATH, 'utils', 'templates',
 # Filter to use in file dialogs
 FILES_FILTER = '{} (*.ipynb)'.format(_('Jupyter notebooks'))
 
+# How long to wait after save before checking whether file exists (in ms)
+WAIT_SAVE_DELAY = 250
+
+# How often to wait for that time
+WAIT_SAVE_ITERATIONS = 20
+
 logger = logging.getLogger(__name__)
 
 
@@ -247,16 +253,33 @@ class NotebookTabWidget(Tabs):
         if not self.is_newly_created(client):
             return filename
 
-        # Read file to see whether notebook is empty
-        wait_save = QEventLoop()
-        QTimer.singleShot(1000, wait_save.quit)
-        wait_save.exec_()
-        nb_contents = nbformat.read(filename, as_version=4)
-        if (len(nb_contents['cells']) == 0
-                or len(nb_contents['cells'][0]['source']) == 0):
+        # Repeatly try reading file to see whether notebook is empty
+        for iteration in range(WAIT_SAVE_ITERATIONS):
+
+            # Wait a bit
+            wait_save = QEventLoop()
+            QTimer.singleShot(WAIT_SAVE_DELAY, wait_save.quit)
+            wait_save.exec_()
+
+            # Try reading the file
+            try:
+                nb_contents = nbformat.read(filename, as_version=4)
+            except FileNotFoundError:
+                logger.debug('File not found')
+                continue
+
+            # If empty, we are done
+            if (len(nb_contents['cells']) == 0
+                    or len(nb_contents['cells'][0]['source']) == 0):
+                return filename
+            else:
+                break
+        else:
+            # It is taking longer than expected;
+            # Just return and hope for the best
             return filename
 
-        # Ask user to save notebook with new filename
+        # Notebook not empty, so ask user to save with new filename
         buttons = QMessageBox.Yes | QMessageBox.No
         text = _("<b>{0}</b> has been modified.<br>"
                  "Do you want to save changes?").format(osp.basename(filename))

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -11,10 +11,12 @@ import os.path as osp
 
 # Third party imports
 import pytest
+from qtpy.QtWidgets import QMessageBox
 
 # Local imports
 from spyder_notebook.utils.servermanager import ServerManager
-from spyder_notebook.widgets.notebooktabwidget import NotebookTabWidget
+from spyder_notebook.widgets.notebooktabwidget import (
+    NotebookTabWidget, WAIT_SAVE_ITERATIONS)
 
 
 @pytest.fixture
@@ -23,11 +25,147 @@ def tabwidget(mocker, qtbot):
     def fake_get_server(filename, start):
         return collections.defaultdict(
             str, filename=filename, notebook_dir=osp.dirname(filename))
+
+    mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.WAIT_SAVE_DELAY', 1)
     fake_server_manager = mocker.Mock(
         spec=ServerManager, get_server=fake_get_server)
     widget = NotebookTabWidget(None, fake_server_manager)
     qtbot.addWidget(widget)
     return widget
+
+
+def test_save_notebook_with_opened_notebook(mocker, tabwidget):
+    """Test that .save_notebook() with a notebook opened from a file does
+    indeed save the notebook but does not try to read it again."""
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read')
+    client = tabwidget.create_new_client('ham.ipynb')
+    client.save = mocker.Mock()
+
+    result = tabwidget.save_notebook(client)
+
+    client.save.assert_called()
+    mock_read.assert_not_called()
+    assert result == 'ham.ipynb'
+
+
+def test_save_notebook_with_empty_new_notebook(mocker, tabwidget):
+    """Test that .save_notebook() on a newly created, empty notebook saves
+    the notebook, reads it back again but does not ask to save it again."""
+    contents = {'cells': []}
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        return_value=contents)
+    mock_question = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question')
+    client = tabwidget.create_new_client()
+    client.save = mocker.Mock()
+
+    result = tabwidget.save_notebook(client)
+
+    client.save.assert_called()
+    mock_read.assert_called_once()
+    mock_question.assert_not_called()
+    assert result.endswith('untitled0.ipynb')
+
+
+def test_save_notebook_with_nonempty_new_notebook_and_save(mocker, tabwidget):
+    """Test that .save_notebook() on a newly created, non-empty notebook saves
+    the notebook, reads it back again, asks to save it again, and if yes, does
+    save it under a new name."""
+    contents = {'cells': [{'source': 'not empty'}]}
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        return_value=contents)
+    mock_question = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
+        return_value=QMessageBox.Yes)
+    client = tabwidget.create_new_client()
+    client.save = mocker.Mock()
+    tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
+
+    result = tabwidget.save_notebook(client)
+
+    client.save.assert_called()
+    mock_read.assert_called_once()
+    mock_question.assert_called_once()
+    tabwidget.save_as.assert_called_once()
+    assert result == 'newname.ipynb'
+
+
+def test_save_notebook_with_nonempty_new_notebook_and_no_save(
+            mocker, tabwidget):
+    """Test that .save_notebook() on a newly created, non-empty notebook saves
+    the notebook, reads it back again, asks to save it again, and if no, does
+    not save it under a new name."""
+    contents = {'cells': [{'source': 'not empty'}]}
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        return_value=contents)
+    mock_question = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
+        return_value=QMessageBox.No)
+    client = tabwidget.create_new_client()
+    client.save = mocker.Mock()
+    tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
+
+    result = tabwidget.save_notebook(client)
+
+    client.save.assert_called()
+    mock_read.assert_called_once()
+    mock_question.assert_called_once()
+    tabwidget.save_as.assert_not_called()
+    assert result.endswith('untitled0.ipynb')
+
+
+def test_save_notebook_with_empty_new_notebook_and_delay(
+            mocker, tabwidget):
+    """Test that .save_notebook() on a newly created, empty notebook saves
+    the notebook and reads it back again, and when that fails because the file
+    does not exists, try again to read it back. When the read succeeds the
+    second time and the notebook turns out to be empty, the user is not asked
+    to save it again."""
+    contents = {'cells': []}
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        side_effect=[FileNotFoundError, contents])
+    mock_question = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
+        return_value=QMessageBox.No)
+    client = tabwidget.create_new_client()
+    client.save = mocker.Mock()
+    tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
+
+    result = tabwidget.save_notebook(client)
+
+    client.save.assert_called()
+    assert mock_read.call_count == 2
+    mock_question.assert_not_called()
+    assert result.endswith('untitled0.ipynb')
+
+
+def test_save_notebook_with_new_notebook_and_long_delay(mocker, tabwidget):
+    """Test that .save_notebook() on a newly created, empty notebook saves
+    the notebook and reads it back again, and when that keeps fails because
+    the file does not exists, eventually gives up and does not ask to save
+    again."""
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        side_effect=FileNotFoundError)
+    mock_question = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
+        return_value=QMessageBox.No)
+    client = tabwidget.create_new_client()
+    client.save = mocker.Mock()
+    tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
+
+    result = tabwidget.save_notebook(client)
+
+    client.save.assert_called()
+    assert mock_read.call_count == WAIT_SAVE_ITERATIONS
+    mock_question.assert_not_called()
+    assert result.endswith('untitled0.ipynb')
 
 
 def test_is_newly_created_with_new_notebook(tabwidget):

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -37,58 +37,52 @@ def tabwidget(mocker, qtbot):
 
 def test_save_notebook_with_opened_notebook(mocker, tabwidget):
     """Test that .save_notebook() with a notebook opened from a file does
-    indeed save the notebook but does not try to read it again."""
-    mock_read = mocker.patch(
-        'spyder_notebook.widgets.notebooktabwidget.nbformat.read')
+    indeed save the notebook but does not check whether it is empty."""
     client = tabwidget.create_new_client('ham.ipynb')
     client.save = mocker.Mock()
+    tabwidget.wait_and_check_if_empty = mocker.Mock()
 
     result = tabwidget.save_notebook(client)
 
     client.save.assert_called()
-    mock_read.assert_not_called()
+    tabwidget.wait_and_check_if_empty.assert_not_called()
     assert result == 'ham.ipynb'
 
 
 def test_save_notebook_with_empty_new_notebook(mocker, tabwidget):
-    """Test that .save_notebook() on a newly created, empty notebook saves
-    the notebook, reads it back again but does not ask to save it again."""
-    contents = {'cells': []}
-    mock_read = mocker.patch(
-        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
-        return_value=contents)
+    """Test that .save_notebook() on a newly created notebook saves the
+    notebook, checks that it is empty, and it is, does not ask to save it
+    again."""
     mock_question = mocker.patch(
         'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question')
     client = tabwidget.create_new_client()
     client.save = mocker.Mock()
+    tabwidget.wait_and_check_if_empty = mocker.Mock(return_value=True)
 
     result = tabwidget.save_notebook(client)
 
     client.save.assert_called()
-    mock_read.assert_called_once()
+    tabwidget.wait_and_check_if_empty.assert_called()
     mock_question.assert_not_called()
     assert result.endswith('untitled0.ipynb')
 
 
 def test_save_notebook_with_nonempty_new_notebook_and_save(mocker, tabwidget):
-    """Test that .save_notebook() on a newly created, non-empty notebook saves
-    the notebook, reads it back again, asks to save it again, and if yes, does
-    save it under a new name."""
-    contents = {'cells': [{'source': 'not empty'}]}
-    mock_read = mocker.patch(
-        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
-        return_value=contents)
+    """Test that .save_notebook() on a newly created notebook saves the
+    notebook, checks that it is empty, and if it is, asks to save it again,
+    and if yes, does save it under a new name."""
     mock_question = mocker.patch(
         'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
         return_value=QMessageBox.Yes)
     client = tabwidget.create_new_client()
     client.save = mocker.Mock()
+    tabwidget.wait_and_check_if_empty = mocker.Mock(return_value=False)
     tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
 
     result = tabwidget.save_notebook(client)
 
     client.save.assert_called()
-    mock_read.assert_called_once()
+    tabwidget.wait_and_check_if_empty.assert_called_once()
     mock_question.assert_called_once()
     tabwidget.save_as.assert_called_once()
     assert result == 'newname.ipynb'
@@ -96,76 +90,82 @@ def test_save_notebook_with_nonempty_new_notebook_and_save(mocker, tabwidget):
 
 def test_save_notebook_with_nonempty_new_notebook_and_no_save(
             mocker, tabwidget):
-    """Test that .save_notebook() on a newly created, non-empty notebook saves
-    the notebook, reads it back again, asks to save it again, and if no, does
-    not save it under a new name."""
-    contents = {'cells': [{'source': 'not empty'}]}
-    mock_read = mocker.patch(
-        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
-        return_value=contents)
+    """Test that .save_notebook() on a newly created notebook saves the
+    notebook, checks that it is empty, and if it is, asks to save it again,
+    and if no, does not save it under a new name."""
     mock_question = mocker.patch(
         'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
         return_value=QMessageBox.No)
     client = tabwidget.create_new_client()
     client.save = mocker.Mock()
+    tabwidget.wait_and_check_if_empty = mocker.Mock(return_value=False)
     tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
 
     result = tabwidget.save_notebook(client)
 
     client.save.assert_called()
-    mock_read.assert_called_once()
+    tabwidget.wait_and_check_if_empty.assert_called_once()
     mock_question.assert_called_once()
     tabwidget.save_as.assert_not_called()
     assert result.endswith('untitled0.ipynb')
 
 
-def test_save_notebook_with_empty_new_notebook_and_delay(
-            mocker, tabwidget):
-    """Test that .save_notebook() on a newly created, empty notebook saves
-    the notebook and reads it back again, and when that fails because the file
-    does not exists, try again to read it back. When the read succeeds the
-    second time and the notebook turns out to be empty, the user is not asked
-    to save it again."""
+def test_wait_and_check_if_empty_when_empty(mocker, tabwidget):
+    """Test that .wait_and_check_if_empty() returns True when called on a
+    notebook that is empty."""
+    contents = {'cells': []}
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        return_value=contents)
+
+    result = tabwidget.wait_and_check_if_empty('ham.ipynb')
+
+    mock_read.assert_called_once()
+    assert result is True
+
+
+def test_wait_and_check_if_empty_when_not_empty(mocker, tabwidget):
+    """Test that .wait_and_check_if_empty() returns False when called on a
+    notebook that is not empty."""
+    contents = {'cells': [{'source': 'not empty'}]}
+    mock_read = mocker.patch(
+        'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
+        return_value=contents)
+
+    result = tabwidget.wait_and_check_if_empty('ham.ipynb')
+
+    mock_read.assert_called_once()
+    assert result is False
+
+
+def test_wait_and_check_if_empty_with_delay(mocker, tabwidget):
+    """Test that .wait_and_check_if_empty() on an empty notebook tries to read
+    it, and when that fails because the file does not exist, it tries again to
+    read it. When the read succeeds the second time and the notebook turns out
+    to be empty, the function returns True."""
     contents = {'cells': []}
     mock_read = mocker.patch(
         'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
         side_effect=[FileNotFoundError, contents])
-    mock_question = mocker.patch(
-        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
-        return_value=QMessageBox.No)
-    client = tabwidget.create_new_client()
-    client.save = mocker.Mock()
-    tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
 
-    result = tabwidget.save_notebook(client)
+    result = tabwidget.wait_and_check_if_empty('ham.ipynb')
 
-    client.save.assert_called()
     assert mock_read.call_count == 2
-    mock_question.assert_not_called()
-    assert result.endswith('untitled0.ipynb')
+    assert result is True
 
 
-def test_save_notebook_with_new_notebook_and_long_delay(mocker, tabwidget):
-    """Test that .save_notebook() on a newly created, empty notebook saves
-    the notebook and reads it back again, and when that keeps fails because
-    the file does not exists, eventually gives up and does not ask to save
-    again."""
+def test_wait_and_check_with_long_delay(mocker, tabwidget):
+    """Test that .wait_and_check_if_empty() repeatedly tries to read the file,
+    and when that keeps failing because the file does not exists, eventually
+    gives up and returns True."""
     mock_read = mocker.patch(
         'spyder_notebook.widgets.notebooktabwidget.nbformat.read',
         side_effect=FileNotFoundError)
-    mock_question = mocker.patch(
-        'spyder_notebook.widgets.notebooktabwidget.QMessageBox.question',
-        return_value=QMessageBox.No)
-    client = tabwidget.create_new_client()
-    client.save = mocker.Mock()
-    tabwidget.save_as = mocker.Mock(return_value='newname.ipynb')
 
-    result = tabwidget.save_notebook(client)
+    result = tabwidget.wait_and_check_if_empty('ham.ipynb')
 
-    client.save.assert_called()
     assert mock_read.call_count == WAIT_SAVE_ITERATIONS
-    mock_question.assert_not_called()
-    assert result.endswith('untitled0.ipynb')
+    assert result is True
 
 
 def test_is_newly_created_with_new_notebook(tabwidget):


### PR DESCRIPTION
When saving a newly created notebook in a temporary directory, we read it back to check whether it is empty; if not, we offer to save it in a more permanent location. Before, we waited one second between initiating the save and reading it back. Now, we wait 0.25 second, but keep trying if the file does not yet exist. This means the function runs faster if the save is expedient and it waits longer if the save runs slowly.

The first commit in the PR is the one providing the functionality, the other commits are refactoring and adding tests.

Fixes #339.
