### PR TITLE
PR: Use interpreter preference when opening new tab

### DIFF
--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -103,7 +103,7 @@ def notebook(qtbot):
 def plugin_no_server(mocker, qtbot):
     """Set up the Notebook plugin with a fake nbopen which does not start
     a notebook server."""
-    def fake_get_server(filename, start):
+    def fake_get_server(filename, interpreter, start):
         return collections.defaultdict(
             str, filename=filename, notebook_dir=osp.dirname(filename))
     fake_server_manager = mocker.Mock(get_server=fake_get_server)

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -278,6 +278,9 @@ def test_new_notebook(notebook, qtbot):
     assert notebook.tabwidget.count() == 2
 
 
+# Teardown sometimes fails on Mac with Python 3.8 due to NoProcessException
+# in shutdown_server() in notebookapp.py in external notebook library
+@flaky
 def test_open_console_when_no_kernel(notebook, qtbot, mocker):
     """Test that open_console() handles the case when there is no kernel."""
     # Create mock IPython console plugin and QMessageBox

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -102,13 +102,13 @@ class ServerManager(QObject):
     """
 
     # A server has started and is now accepting requests
-    sig_server_started = Signal()
+    sig_server_started = Signal(ServerProcess)
 
     # We tried to start a server but it took too long to start up
-    sig_server_timed_out = Signal()
+    sig_server_timed_out = Signal(ServerProcess)
 
     # We tried to start a server but an error occurred
-    sig_server_errored = Signal()
+    sig_server_errored = Signal(ServerProcess)
 
     def __init__(self, dark_theme=False):
         """
@@ -249,7 +249,7 @@ class ServerManager(QObject):
                 logger.debug('Notebook server for %s timed out',
                              server_process.notebook_dir)
                 server_process.state = ServerState.TIMED_OUT
-                self.sig_server_timed_out.emit()
+                self.sig_server_timed_out.emit(server_process)
             else:
                 QTimer.singleShot(
                     CHECK_SERVER_UP_DELAY,
@@ -259,7 +259,7 @@ class ServerManager(QObject):
         logger.debug('Server for %s started', server_process.notebook_dir)
         server_process.state = ServerState.RUNNING
         server_process.server_info = server_info
-        self.sig_server_started.emit()
+        self.sig_server_started.emit(server_process)
 
     def shutdown_all_servers(self):
         """Shutdown all running servers."""
@@ -307,7 +307,7 @@ class ServerManager(QObject):
         logger.debug('Server for %s encountered error %s',
                      server_process.notebook_dir, str(error))
         server_process.state = ServerState.ERROR
-        self.sig_server_errored.emit()
+        self.sig_server_errored.emit(server_process)
 
     def handle_finished(self, server_process, code, status):
         """

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -53,7 +53,7 @@ class ServerProcess():
     This is a data class.
     """
 
-    def __init__(self, process, notebook_dir, starttime=None,
+    def __init__(self, process, notebook_dir, interpreter, starttime=None,
                  state=ServerState.STARTING, server_info=None, output=''):
         """
         Construct a ServerProcess.
@@ -64,6 +64,8 @@ class ServerProcess():
             The process described by this instance.
         notebook_dir : str
             Directory from which the server can render notebooks.
+        interpreter : str
+            File name of Python interpreter used to render notebooks.
         starttime : datetime or None, optional
             Time at which the process was started. The default is None,
             meaning that the current time should be used.
@@ -79,6 +81,7 @@ class ServerProcess():
         """
         self.process = process
         self.notebook_dir = notebook_dir
+        self.interpreter = interpreter
         self.starttime = starttime or datetime.datetime.now()
         self.state = state
         self.server_info = server_info
@@ -124,19 +127,22 @@ class ServerManager(QObject):
         self.dark_theme = dark_theme
         self.servers = []
 
-    def get_server(self, filename, start=True):
+    def get_server(self, filename, interpreter, start=True):
         """
         Return server which can render a notebook or potentially start one.
 
         Return the server info of a server managed by this object which can
-        render the notebook with the given file name. If no such server
-        exists and `start` is True, then start up a server asynchronously
-        (unless a suitable server is already in the process of starting up).
+        render the notebook with the given file name and which uses the given
+        interpreter. If no such server exists and `start` is True, then start
+        up a server asynchronously (unless a suitable server is already in the
+        process of starting up).
 
         Parameters
         ----------
         filename : str
             File name of notebook which is to be rendered.
+        interpreter : str
+            File name of Python interpreter to be used.
         start : bool, optional
             Whether to start up a server if none exists. The default is True.
 
@@ -148,7 +154,8 @@ class ServerManager(QObject):
         """
         filename = osp.abspath(filename)
         for server in self.servers:
-            if filename.startswith(server.notebook_dir):
+            if (filename.startswith(server.notebook_dir)
+                    and interpreter == server.interpreter):
                 if server.state == ServerState.RUNNING:
                     return server.server_info
                 elif server.state == ServerState.STARTING:
@@ -156,22 +163,24 @@ class ServerManager(QObject):
                                  server.notebook_dir)
                     return None
         if start:
-            self.start_server(filename)
+            self.start_server(filename, interpreter)
         return None
 
-    def start_server(self, filename):
+    def start_server(self, filename, interpreter):
         """
         Start a notebook server asynchronously.
 
         Start a server which can render the given notebook and return
-        immediately. The manager will check periodically whether the server is
-        accepting requests and emit `sig_server_started` or
-        `sig_server_timed_out` when appropriate.
+        immediately. Assume the server uses the given interpreter. The manager
+        will check periodically whether the server is accepting requests and
+        emit `sig_server_started` or `sig_server_timed_out` when appropriate.
 
         Parameters
         ----------
         filename : str
             File name of notebook to be rendered by the server.
+        interpreter : str
+            File name of Python interpreter to be used.
         """
         home_dir = get_home_dir()
         if filename.startswith(home_dir):
@@ -197,7 +206,8 @@ class ServerManager(QObject):
             env.insert('PYTHONPATH', osp.dirname(get_module_path('spyder')))
             process.setProcessEnvironment(env)
 
-        server_process = ServerProcess(process, notebook_dir=nbdir)
+        server_process = ServerProcess(
+            process, notebook_dir=nbdir, interpreter=interpreter)
         process.setProcessChannelMode(QProcess.MergedChannels)
         process.readyReadStandardOutput.connect(
             lambda: self.read_server_output(server_process))

--- a/spyder_notebook/widgets/serverinfo.py
+++ b/spyder_notebook/widgets/serverinfo.py
@@ -62,6 +62,11 @@ class ServerInfoDialog(BaseDialog):
         self.dir_lineedit.setReadOnly(True)
         self.formlayout.addRow(_('Notebook dir:'), self.dir_lineedit)
 
+        self.interpreter_lineedit = QLineEdit(self)
+        self.interpreter_lineedit.setReadOnly(True)
+        self.formlayout.addRow(_('Python interpreter:'),
+                               self.interpreter_lineedit)
+
         self.state_lineedit = QLineEdit(self)
         self.state_lineedit.setReadOnly(True)
         self.formlayout.addRow(_('State:'), self.state_lineedit)
@@ -88,6 +93,7 @@ class ServerInfoDialog(BaseDialog):
 
     def select_process(self, index):
         self.dir_lineedit.setText(self.servers[index].notebook_dir)
+        self.interpreter_lineedit.setText(self.servers[index].interpreter)
         self.state_lineedit.setText(
             SERVER_STATE_DESCRIPTIONS[self.servers[index].state])
         self.log_textedit.setPlainText(self.servers[index].output)
@@ -103,9 +109,11 @@ def test():  # pragma: no cover
             return self.pid
 
     servers = [ServerProcess(FakeProcess(42), '/my/home/dir',
+                             '/ham/interpreter',
                              state=ServerState.RUNNING,
                              output='Nicely humming along...\n'),
                ServerProcess(FakeProcess(404), '/some/other/dir',
+                             '/spam/interpreter',
                              state=ServerState.FINISHED,
                              output='Terminated for some reason...\n')]
 

--- a/spyder_notebook/widgets/tests/test_notebooktabwidget.py
+++ b/spyder_notebook/widgets/tests/test_notebooktabwidget.py
@@ -22,7 +22,7 @@ from spyder_notebook.widgets.notebooktabwidget import (
 @pytest.fixture
 def tabwidget(mocker, qtbot):
     """Create an empty NotebookTabWidget which does not start up servers."""
-    def fake_get_server(filename, start):
+    def fake_get_server(filename, interpreter, start):
         return collections.defaultdict(
             str, filename=filename, notebook_dir=osp.dirname(filename))
 

--- a/spyder_notebook/widgets/tests/test_serverinfo.py
+++ b/spyder_notebook/widgets/tests/test_serverinfo.py
@@ -29,9 +29,11 @@ class FakeProcess:
 def dialog(qtbot):
     """Construct and return dialog window for testing."""
     servers = [ServerProcess(FakeProcess(42), '/my/home/dir',
+                             interpreter='/ham/interpreter',
                              state=ServerState.RUNNING,
                              output='Nicely humming along...\n'),
                ServerProcess(FakeProcess(404), '/some/other/dir',
+                             interpreter='/spam/interpreter',
                              state=ServerState.FINISHED,
                              output='Terminated for some reason...\n')]
     res = ServerInfoDialog(servers)

--- a/spyder_notebook/widgets/tests/test_serverinfo.py
+++ b/spyder_notebook/widgets/tests/test_serverinfo.py
@@ -49,6 +49,7 @@ def test_dialog_on_initialization(dialog):
     assert dialog.process_combo.itemText(1) == '404'
     assert dialog.state_lineedit.text() == 'Running'
     assert dialog.dir_lineedit.text() == '/my/home/dir'
+    assert dialog.interpreter_lineedit.text() == '/ham/interpreter'
     assert dialog.log_textedit.toPlainText() == 'Nicely humming along...\n'
 
 
@@ -61,5 +62,6 @@ def test_dialog_change_process(dialog):
     assert dialog.process_combo.currentText() == '404'
     assert dialog.state_lineedit.text() == 'Finished'
     assert dialog.dir_lineedit.text() == '/some/other/dir'
+    assert dialog.interpreter_lineedit.text() == '/spam/interpreter'
     assert (dialog.log_textedit.toPlainText()
             == 'Terminated for some reason...\n')


### PR DESCRIPTION
Record the Python interpreter selected in the Spyder preferences when a notebook server is started. When a new tab is opened, only use an existing server if it uses the interpreter that is set in the preferences when the tab is opened, otherwise start a new server which will use the current interpreter. The effect is that if the user changes the Python interpreter, new notebooks will use the new interpreter.

Also, update and add tests, and display the Python interpreter in the Server Info dialog window.

Fixes #266.

