### PR TITLE
PR: Some style fixes so it looks better in Spyder 5

### DIFF
--- a/spyder_notebook/utils/templates/welcome-dark.html
+++ b/spyder_notebook/utils/templates/welcome-dark.html
@@ -626,11 +626,10 @@ hr {
         <div class = "row">
             <div class = "col-md-12 twelve columns">
 <h1 id="section"></h1>
-<h1 id="welcome-to-the-notebook-plugin">Welcome to the Notebook plugin</h1>
-<h2 id="usage">Usage</h2>
-<p>With this plugin you can open, edit and create Jupyter notebooks.</p>
-<p>To create new notebooks, you can right-click and click in <em>Open new notebook</em>. You can also click the <span title="Open new notebook"><b>+</b></span> button.</p>
-<p>To open and save notebooks, please press the <span title="Options"><b>&#9881;</b></span> button to the right of this plugin.</p>
+<h1 id="welcome-to-the-notebook-plugin">Welcome to Spyder-Notebook</h1>
+<p>Here you can open, edit and create Jupyter notebooks.</p>
+<p>To create new notebooks, you can right-click and then click in <em>Open new notebook</em>. You can also click the <span title="Open new notebook"><b>&#xFF0B;</b></span> button on the top right of this pane.</p>
+<p>To open and save notebooks, click the <span title="Options">&#9776;</span> button on the top right too.</p>
 
     <HR/>
             </div>

--- a/spyder_notebook/utils/templates/welcome.html
+++ b/spyder_notebook/utils/templates/welcome.html
@@ -614,11 +614,10 @@ img {max-width : 100%}
         <div class = "row">
             <div class = "col-md-12 twelve columns">
 <h1 id="section"></h1>
-<h1 id="welcome-to-the-notebook-plugin">Welcome to the Notebook plugin</h1>
-<h2 id="usage">Usage</h2>
-<p>With this plugin you can open, edit and create Jupyter notebooks.</p>
-<p>To create new notebooks, you can right-click and click in <em>Open new notebook</em>. You can also click the <span title="Open new notebook"><b>+</b></span> button.</p>
-<p>To open and save notebooks, please press the <span title="Options"><b>&#9881;</b></span> button to the right of this plugin.</p>
+<h1 id="welcome-to-the-notebook-plugin">Welcome to Spyder-Notebook</h1>
+<p>Here you can open, edit and create Jupyter notebooks.</p>
+<p>To create new notebooks, you can right-click and then click in <em>Open new notebook</em>. You can also click the <span title="Open new notebook"><b>&#xFF0B;</b></span> button on the top right of this pane.</p>
+<p>To open and save notebooks, click the <span title="Options">&#9776;</span> button on the top right too.</p>
 
     <HR/>
             </div>

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -16,7 +16,7 @@ import sys
 from notebook.utils import url_path_join, url_escape
 import qstylizer
 from qtpy.QtCore import QEvent, QUrl, Qt, Signal
-from qtpy.QtGui import QFontMetrics, QFont
+from qtpy.QtGui import QColor, QFontMetrics, QFont
 from qtpy.QtWebEngineWidgets import (QWebEnginePage, QWebEngineSettings,
                                      QWebEngineView, WEBENGINE)
 from qtpy.QtWidgets import (QApplication, QMenu, QFrame, QVBoxLayout,
@@ -121,6 +121,11 @@ class NotebookWidget(DOMWidget):
         # Path for css files in Spyder according to the interface theme set by
         # the user (i.e. dark or light).
         self.css_path = self.get_conf('css_path', section='appearance')
+
+        # Set default background color.
+        self.page().setBackgroundColor(
+            QColor(QStylePalette.COLOR_BACKGROUND_1)
+        )
 
     def contextMenuEvent(self, event):
         """

--- a/spyder_notebook/widgets/client.py
+++ b/spyder_notebook/widgets/client.py
@@ -43,7 +43,6 @@ from spyder_notebook.widgets.dom import DOMWidget
 # later it'll be a good idea to create a new one.
 
 PLUGINS_PATH = get_module_source_path('spyder', 'plugins')
-CSS_PATH = osp.join(PLUGINS_PATH, 'help', 'utils', 'static', 'css')
 TEMPLATES_PATH = osp.join(
     PLUGINS_PATH, 'ipythonconsole', 'assets', 'templates')
 
@@ -119,6 +118,10 @@ class NotebookWidget(DOMWidget):
         self.setup()
         self.actions = actions
 
+        # Path for css files in Spyder according to the interface theme set by
+        # the user (i.e. dark or light).
+        self.css_path = self.get_conf('css_path', section='appearance')
+
     def contextMenuEvent(self, event):
         """
         Handle context menu events.
@@ -161,9 +164,15 @@ class NotebookWidget(DOMWidget):
         menu.popup(event.globalPos())
         event.accept()
 
+    def _set_info(self, html):
+        """Set informational html with css from local path."""
+        self.setHtml(html, QUrl.fromLocalFile(self.css_path))
+
     def show_blank(self):
         """Show a blank page."""
-        self.setHtml(BLANK)
+        blank_template = Template(BLANK)
+        page = blank_template.substitute(css_path=self.css_path)
+        self._set_info(page)
 
     def show_kernel_error(self, error):
         """Show kernel initialization errors."""
@@ -177,10 +186,10 @@ class NotebookWidget(DOMWidget):
 
         message = _("An error occurred while starting the kernel")
         kernel_error_template = Template(KERNEL_ERROR)
-        page = kernel_error_template.substitute(css_path=CSS_PATH,
+        page = kernel_error_template.substitute(css_path=self.css_path,
                                                 message=message,
                                                 error=error)
-        self.setHtml(page)
+        self._set_info(page)
 
     def show_loading_page(self):
         """Show a loading animation while the kernel is starting."""
@@ -189,10 +198,10 @@ class NotebookWidget(DOMWidget):
         if os.name == 'nt':
             loading_img = loading_img.replace('\\', '/')
         message = _("Connecting to kernel...")
-        page = loading_template.substitute(css_path=CSS_PATH,
+        page = loading_template.substitute(css_path=self.css_path,
                                            loading_img=loading_img,
                                            message=message)
-        self.setHtml(page)
+        self._set_info(page)
 
     def show_message(self, page):
         """Show a message page with the given .html file."""

--- a/spyder_notebook/widgets/main_widget.py
+++ b/spyder_notebook/widgets/main_widget.py
@@ -43,9 +43,7 @@ class NotebookMainWidgetMenus:
 
 class NotebookMainWidgetOptionsMenuSections:
     Open = 'Open'
-    SaveAs = 'Save as'
-    Console = 'Console'
-    ServerInfo = 'Server info'
+    Other = 'Other'
 
 
 class NotebookMainWidgetRecentNotebooksMenuSections:
@@ -172,21 +170,13 @@ class NotebookMainWidget(PluginMainWidget):
                 section=NotebookMainWidgetOptionsMenuSections.Open,
             )
 
-        self.add_item_to_menu(
-            self.save_as_action,
-            menu=options_menu,
-            section=NotebookMainWidgetOptionsMenuSections.SaveAs,
-        )
-        self.add_item_to_menu(
-            self.open_console_action,
-            menu=options_menu,
-            section=NotebookMainWidgetOptionsMenuSections.Console,
-        )
-        self.add_item_to_menu(
-            self.server_info_action,
-            menu=options_menu,
-            section=NotebookMainWidgetOptionsMenuSections.ServerInfo,
-        )
+        for item in [self.save_as_action, self.open_console_action,
+                     self.server_info_action]:
+            self.add_item_to_menu(
+                item,
+                menu=options_menu,
+                section=NotebookMainWidgetOptionsMenuSections.Other,
+            )
 
     def update_actions(self):
         """Update actions of the options menu."""


### PR DESCRIPTION
- Show border around `NotebookWidget`
- Improve welcome message a bit (make it simpler to read and update icons).
- Use Spyder main background color when creating new `NotebookWidget`'s.

This is how it looks now:

![image](https://user-images.githubusercontent.com/365293/188238388-d7c90c59-e04d-4157-b769-9edfe66a88bf.png)
