### PR TITLE
Add menu item "Toggle All Line Numbers"

### DIFF
--- a/spyder_notebook/_version.py
+++ b/spyder_notebook/_version.py
@@ -1,3 +1,3 @@
 """Version File."""
-VERSION_INFO = (0, 4, 0, 'dev0')
+VERSION_INFO = (0, 4, 1, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/spyder_notebook/server/src/commands.ts
+++ b/spyder_notebook/server/src/commands.ts
@@ -837,6 +837,8 @@ export const SetupCommands = (
   viewMenu.insertItem(6, { command: cmdIds.showOutput });
   viewMenu.insertItem(7, { command: cmdIds.showAllCode });
   viewMenu.insertItem(8, { command: cmdIds.showAllOutputs });
+  viewMenu.insertItem(9, { type: 'separator' });
+  viewMenu.insertItem(10, { command: cmdIds.toggleAllLines });
 
   // Create Run menu.
   let runMenu = new Menu({ commands });

--- a/spyder_notebook/server/webpack.config.js
+++ b/spyder_notebook/server/webpack.config.js
@@ -1,8 +1,16 @@
+const crypto = require('crypto');
+
+// Workaround for loaders using "md4" by default, which is not supported in FIPS-compliant OpenSSL
+const cryptoOrigCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+cryptoOrigCreateHash(algorithm == 'md4' ? 'sha256' : algorithm);
+
 module.exports = {
   entry: ['whatwg-fetch', './build/index.js'],
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js'
+    filename: 'bundle.js',
+    hashFunction: 'sha256'
   },
   bail: true,
   devtool: 'cheap-source-map',


### PR DESCRIPTION
This adds a menu item "Toggle All Line Numbers" to the notebook View menu, which toggles the display of line numbers in the notebook cells, as shown in the animation below.

Ideally, there should be a tick mark in the menu item to indicate whether it is toggled on or off, but it is not immediately obvious to me how to do this and the code in this PR will be overwritten in version 0.5.x so I don't feel like putting too much effort in it.

Commit 4c100e1 is unrelated but necessary to compile the code in nodejs 18.

Fixes #403.

![spynb-lineno](https://user-images.githubusercontent.com/7941918/227039599-91ae52ef-044b-417f-86c9-ee385278828e.gif)
