### PR TITLE
PR: Specify file for storing connection info when starting server

### DIFF
--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -6,17 +6,18 @@
 import os
 from jinja2 import FileSystemLoader
 from notebook.base.handlers import IPythonHandler, FileFindHandler
-from notebook.notebookapp import flags, NotebookApp
+from notebook.notebookapp import aliases, flags, NotebookApp
 from notebook.utils import url_path_join as ujoin
-from traitlets import Bool
+from traitlets import Bool, Dict, Unicode
 
 HERE = os.path.dirname(__file__)
+
+aliases['info-file'] = 'SpyderNotebookServer.info_file_cmdline'
 
 flags['dark'] = (
     {'SpyderNotebookServer': {'dark_theme': True}},
     'Use dark theme when rendering notebooks'
 )
-
 
 class NotebookHandler(IPythonHandler):
     """
@@ -55,15 +56,23 @@ class NotebookHandler(IPythonHandler):
 class SpyderNotebookServer(NotebookApp):
     """Server rendering notebooks in HTML and serving them over HTTP."""
 
-    flags = flags
+    flags = Dict(flags)
+    aliases = Dict(aliases)
 
     dark_theme = Bool(
         False, config=True,
         help='Whether to use dark theme when rendering notebooks')
 
+    info_file_cmdline = Unicode(
+        '', config=True,
+        help='Name of file in Jupyter runtime dir with connection info')
+
     def init_webapp(self):
         """Initialize tornado webapp and httpserver."""
         self.tornado_settings['dark_theme'] = self.dark_theme
+        if self.info_file_cmdline:
+            self.info_file = os.path.join(
+                self.runtime_dir, self.info_file_cmdline)
 
         super().init_webapp()
 

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -266,7 +266,7 @@ class ServerManager(QObject):
             with open(filename, encoding='utf-8') as f:
                 server_info = json.load(f)
         except OSError:  # E.g., file does not exist
-            logger.debug('_check_server_started: OSError')
+            logger.debug(f'OSError when opening {filename}')
             delay = datetime.datetime.now() - server_process.starttime
             if delay > datetime.timedelta(seconds=SERVER_TIMEOUT_DELAY):
                 logger.debug('Notebook server for %s timed out',

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -54,7 +54,7 @@ class ServerProcess:
     This is a data class.
     """
 
-    def __init__(self, process, notebook_dir, interpreter, infofile,
+    def __init__(self, process, notebook_dir, interpreter, info_file,
                  starttime=None, state=ServerState.STARTING, server_info=None,
                  output=''):
         """
@@ -68,7 +68,7 @@ class ServerProcess:
             Directory from which the server can render notebooks.
         interpreter : str
             File name of Python interpreter used to render notebooks.
-        infofile : str
+        info_file : str
             Name of JSON file in jupyter_runtime_dir() with connection
             information for the server.
         starttime : datetime or None, optional
@@ -77,7 +77,7 @@ class ServerProcess:
         state : ServerState, optional
             State of the server process. The default is ServerState.STARTING.
         server_info : dict or None, optional
-            If set, this is a dict with the information in infofile. It has
+            If set, this is a dict with the information in info_file. It has
             keys like 'url' and 'token'. The default is None.
         output : str
             Output of the server process from stdout and stderr. The default
@@ -86,7 +86,7 @@ class ServerProcess:
         self.process = process
         self.notebook_dir = notebook_dir
         self.interpreter = interpreter
-        self.infofile = infofile
+        self.info_file = info_file
         self.starttime = starttime or datetime.datetime.now()
         self.state = state
         self.server_info = server_info
@@ -203,9 +203,9 @@ class ServerManager(QObject):
         serverscript = osp.normpath(serverscript)
         my_pid = os.getpid()
         server_index = len(self.servers) + 1
-        infofile = f'spynbserver-{my_pid}-{server_index}.json'
+        info_file = f'spynbserver-{my_pid}-{server_index}.json'
         arguments = [serverscript, '--no-browser',
-                     f'--info-file={infofile}',
+                     f'--info-file={info_file}',
                      f'--notebook-dir={nbdir}',
                      '--NotebookApp.password=',
                      f'--KernelSpecManager.kernel_spec_class={KERNELSPEC}']
@@ -220,7 +220,7 @@ class ServerManager(QObject):
 
         server_process = ServerProcess(
             process, notebook_dir=nbdir, interpreter=interpreter,
-            infofile=infofile)
+            info_file=info_file)
         process.setProcessChannelMode(QProcess.MergedChannels)
         process.readyReadStandardOutput.connect(
             lambda: self.read_server_output(server_process))
@@ -260,7 +260,7 @@ class ServerManager(QObject):
             return
 
         runtime_dir = jupyter_runtime_dir()
-        filename = osp.join(runtime_dir, server_process.infofile)
+        filename = osp.join(runtime_dir, server_process.info_file)
 
         try:
             with open(filename, encoding='utf-8') as f:

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -10,6 +10,7 @@ import datetime
 import enum
 import json
 import logging
+import os
 import os.path as osp
 import sys
 
@@ -53,8 +54,9 @@ class ServerProcess:
     This is a data class.
     """
 
-    def __init__(self, process, notebook_dir, interpreter, starttime=None,
-                 state=ServerState.STARTING, server_info=None, output=''):
+    def __init__(self, process, notebook_dir, interpreter, infofile,
+                 starttime=None, state=ServerState.STARTING, server_info=None,
+                 output=''):
         """
         Construct a ServerProcess.
 
@@ -66,15 +68,17 @@ class ServerProcess:
             Directory from which the server can render notebooks.
         interpreter : str
             File name of Python interpreter used to render notebooks.
+        infofile : str
+            Name of JSON file in jupyter_runtime_dir() with connection
+            information for the server.
         starttime : datetime or None, optional
             Time at which the process was started. The default is None,
             meaning that the current time should be used.
         state : ServerState, optional
             State of the server process. The default is ServerState.STARTING.
         server_info : dict or None, optional
-            If set, this is a dict with information given by the server in
-            a JSON file in jupyter_runtime_dir(). It has keys like 'url' and
-            'token'. The default is None.
+            If set, this is a dict with the information in infofile. It has
+            keys like 'url' and 'token'. The default is None.
         output : str
             Output of the server process from stdout and stderr. The default
             is ''.
@@ -82,6 +86,7 @@ class ServerProcess:
         self.process = process
         self.notebook_dir = notebook_dir
         self.interpreter = interpreter
+        self.infofile = infofile
         self.starttime = starttime or datetime.datetime.now()
         self.state = state
         self.server_info = server_info
@@ -175,6 +180,10 @@ class ServerManager(QObject):
         will check periodically whether the server is accepting requests and
         emit `sig_server_started` or `sig_server_timed_out` when appropriate.
 
+        Every server uses a unique file to store its connection number in.
+        The name of this file is based on `self.servers`, under the assumption
+        that entries are never removed from this list.
+
         Parameters
         ----------
         filename : str
@@ -192,11 +201,14 @@ class ServerManager(QObject):
         process = QProcess(None)
         serverscript = osp.join(osp.dirname(__file__), '../server/main.py')
         serverscript = osp.normpath(serverscript)
+        my_pid = os.getpid()
+        server_index = len(self.servers) + 1
+        infofile = f'spynbserver-{my_pid}-{server_index}.json'
         arguments = [serverscript, '--no-browser',
-                     '--notebook-dir={}'.format(nbdir),
+                     f'--info-file={infofile}',
+                     f'--notebook-dir={nbdir}',
                      '--NotebookApp.password=',
-                     '--KernelSpecManager.kernel_spec_class={}'.format(
-                           KERNELSPEC)]
+                     f'--KernelSpecManager.kernel_spec_class={KERNELSPEC}']
         if self.dark_theme:
             arguments.append('--dark')
         logger.debug('Arguments: %s', repr(arguments))
@@ -207,7 +219,8 @@ class ServerManager(QObject):
             process.setProcessEnvironment(env)
 
         server_process = ServerProcess(
-            process, notebook_dir=nbdir, interpreter=interpreter)
+            process, notebook_dir=nbdir, interpreter=interpreter,
+            infofile=infofile)
         process.setProcessChannelMode(QProcess.MergedChannels)
         process.readyReadStandardOutput.connect(
             lambda: self.read_server_output(server_process))
@@ -246,14 +259,14 @@ class ServerManager(QObject):
         if server_process.state != ServerState.STARTING:
             return
 
-        pid = server_process.process.processId()
         runtime_dir = jupyter_runtime_dir()
-        filename = osp.join(runtime_dir, 'nbserver-{}.json'.format(pid))
+        filename = osp.join(runtime_dir, server_process.infofile)
 
         try:
             with open(filename, encoding='utf-8') as f:
                 server_info = json.load(f)
         except OSError:  # E.g., file does not exist
+            logger.debug('_check_server_started: OSError')
             delay = datetime.datetime.now() - server_process.starttime
             if delay > datetime.timedelta(seconds=SERVER_TIMEOUT_DELAY):
                 logger.debug('Notebook server for %s timed out',

--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -450,14 +450,13 @@ class NotebookTabWidget(Tabs, SpyderConfigurationAccessor):
         process : ServerProcess
             Info about the server that has started.
         """
-        pid = process.process.processId()
         for client_index in range(self.count()):
             client = self.widget(client_index)
             if not client.static and not client.server_url:
                 logger.debug('Getting server for %s', client.filename)
                 server_info = self.server_manager.get_server(
                     client.filename, process.interpreter, start=False)
-                if server_info and server_info['pid'] == pid:
+                if server_info:
                     logger.debug('Success')
                     client.register(server_info)
                     client.load_notebook()

--- a/spyder_notebook/widgets/tests/test_serverinfo.py
+++ b/spyder_notebook/widgets/tests/test_serverinfo.py
@@ -30,12 +30,12 @@ def dialog(qtbot):
     """Construct and return dialog window for testing."""
     servers = [ServerProcess(FakeProcess(42), '/my/home/dir',
                              interpreter='/ham/interpreter',
-                             infofile='info1.json',
+                             info_file='info1.json',
                              state=ServerState.RUNNING,
                              output='Nicely humming along...\n'),
                ServerProcess(FakeProcess(404), '/some/other/dir',
                              interpreter='/spam/interpreter',
-                             infofile='info2.json',
+                             info_file='info2.json',
                              state=ServerState.FINISHED,
                              output='Terminated for some reason...\n')]
     res = ServerInfoDialog(servers)

--- a/spyder_notebook/widgets/tests/test_serverinfo.py
+++ b/spyder_notebook/widgets/tests/test_serverinfo.py
@@ -30,10 +30,12 @@ def dialog(qtbot):
     """Construct and return dialog window for testing."""
     servers = [ServerProcess(FakeProcess(42), '/my/home/dir',
                              interpreter='/ham/interpreter',
+                             infofile='info1.json',
                              state=ServerState.RUNNING,
                              output='Nicely humming along...\n'),
                ServerProcess(FakeProcess(404), '/some/other/dir',
                              interpreter='/spam/interpreter',
+                             infofile='info2.json',
                              state=ServerState.FINISHED,
                              output='Terminated for some reason...\n')]
     res = ServerInfoDialog(servers)


### PR DESCRIPTION
Add a command line parameter to the notebook server for specifying the file in which connection information is to be stored. Use this parameter to set the file name to spynbserver-NNNN-MM.json where NNNN is the PID of the Spyder process and MM distinguishes between the notebook servers started by Spyder.

The reason for this is that Jupyter by default uses nbserver-XXXX.json where XXXX is the PID of the notebook server process, but in a venv in Windows there is no good method for finding this PID.

Fixes #398 