### PR TITLE
PR: Require Spyder version 5.4.3

### DIFF
--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,4 +1,4 @@
-spyder >=5.3.3,<6
+spyder >=5.4.3,<6
 jinja2
 jupyter_core
 nbformat

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ if any([arg == 'bdist_wheel' for arg in sys.argv]):
 
 
 REQUIREMENTS = [
-    'spyder>=5.3.3,<6',
+    'spyder>=5.4.3,<6',
     'jinja2',
     'jupyter_core',
     'nbformat',


### PR DESCRIPTION
Spyder version 5.4.3 includes PR spyder-ide/spyder#20482 which is needed on some Linux systems to display the notebooks.

Fixes #386.