### PR TITLE
PR: Use Spyder prefs to set light/dark notebook theme

### DIFF
--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -145,7 +145,7 @@ class NotebookPlugin(SpyderDockablePlugin):
         corresponds to this plugin, then ignore it. Otherwise, switch to
         selected item in notebook plugin and hide the switcher.
         """
-        if item.get_section() != self.get_title():
+        if item.get_section() != self.get_name():
             return
 
         client = item.get_data()

--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -4,17 +4,28 @@
 """Entry point for server rendering notebooks for Spyder."""
 
 import os
-from notebook.app import aliases, JupyterNotebookApp, NotebookBaseHandler
+from notebook.app import (
+    aliases, flags, JupyterNotebookApp, NotebookBaseHandler)
 from tornado import web
-from traitlets import default, Unicode
+from traitlets import default, Bool, Unicode
 
 HERE = os.path.dirname(__file__)
 
 aliases['info-file'] = 'SpyderNotebookApp.info_file_cmdline'
 
+flags['dark'] = (
+    {'SpyderNotebookApp': {'dark_theme': True}},
+    'Use dark theme when rendering notebooks'
+)
+
 
 class SpyderNotebookHandler(NotebookBaseHandler):
     """A notebook page handler for Spyder."""
+
+    def get_page_config(self):
+        page_config = super().get_page_config()
+        page_config['darkTheme'] = self.extensionapp.dark_theme
+        return page_config
 
     @web.authenticated
     def get(self, path=None):
@@ -30,7 +41,15 @@ class SpyderNotebookApp(JupyterNotebookApp):
     name = 'spyder_notebook'
     file_url_prefix = "/spyder-notebooks"
 
+    flags = dict(flags)
     aliases = dict(aliases)
+
+    dark_theme = Bool(
+        False, config=True,
+        help='Whether to use dark theme when rendering notebooks')
+
+    flags = flags
+
     info_file_cmdline = Unicode(
         '', config=True,
         help='Name of file in Jupyter runtime dir with connection info')

--- a/spyder_notebook/server/packages/application-extension/src/index.ts
+++ b/spyder_notebook/server/packages/application-extension/src/index.ts
@@ -9,6 +9,10 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
+import { IThemeManager } from '@jupyterlab/apputils';
+
+import { PageConfig } from '@jupyterlab/coreutils';
+
 import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
@@ -81,11 +85,32 @@ const menus: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin to sync the notebook theme with the Spyder preferences
+ *
+ * On startup, read the `darkTheme` option from `PageConfig` and then set the
+ * notebook theme accordingly. This option is set in `SpyderNotebookHandler`.
+ */
+const theme: JupyterFrontEndPlugin<void> = {
+  id: '@spyder-notebook/application-extension:theme',
+  requires: [IThemeManager],
+  autoStart: true,
+  activate: (app: JupyterFrontEnd, themeManager: IThemeManager) => {
+    const darkTheme = PageConfig.getOption('darkTheme');
+    if (darkTheme == 'true') {
+      themeManager.setTheme('JupyterLab Dark');
+    } else {
+      themeManager.setTheme('JupyterLab Light');
+    }
+  }
+};
+
+/**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
   menus,
-  opener
+  opener,
+  theme
 ];
 
 export default plugins;

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -210,8 +210,9 @@ class ServerManager(QObject):
                      f'--notebook-dir={nbdir}',
                      '--ServerApp.password=',
                      f'--KernelSpecManager.kernel_spec_class={KERNELSPEC}']
+        if self.dark_theme:
+            arguments.append('--dark')
 
-        # TODO: Add support for dark theme
         logger.debug('Arguments: %s', repr(arguments))
 
         if DEV:

--- a/spyder_notebook/utils/tests/test_servermanager.py
+++ b/spyder_notebook/utils/tests/test_servermanager.py
@@ -74,14 +74,14 @@ def test_get_server_with_server(
         mock_start.assert_not_called()
 
 
-@pytest.mark.parametrize('under_home', [True, False])
-def test_start_server(mocker, under_home):
+@pytest.mark.parametrize(('dark', 'under_home'),
+                         [(True, True), (False, True), (False, False)])
+def test_start_server(mocker, dark, under_home):
     """
     Test that .start_server() starts a process with the correct arguments,
     that it stores the server process in `.servers`; and that it calls
     ._check_server_running().
     """
-    dark = 'not used'
     serverManager = ServerManager(dark)
     mock_check = mocker.patch.object(serverManager, '_check_server_started')
     mock_QProcess = mocker.patch(
@@ -100,6 +100,7 @@ def test_start_server(mocker, under_home):
     mock_QProcess.return_value.start.assert_called_once()
     args = mock_QProcess.return_value.start.call_args[0]
     assert '--notebook-dir={}'.format(nbdir) in args[1]
+    assert ('--dark' in args[1]) == dark
     assert len(serverManager.servers) == 1
     assert serverManager.servers[0].process == mock_QProcess.return_value
     assert serverManager.servers[0].notebook_dir == nbdir


### PR DESCRIPTION
This fixes some functionality that was left out of the big PR #396: the Spyder prefs has a Notebook pane in which the user can choose to use the light or dark theme, but the notebook did not actually follow this setting.

The PR also fixes my typo in PR #417.

Fixes #402.