### PR TITLE
PR: Remove notebook menu items that do not work properly

### DIFF
--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -25,6 +25,16 @@ class SpyderNotebookHandler(NotebookBaseHandler):
     def get_page_config(self):
         page_config = super().get_page_config()
         page_config['darkTheme'] = self.extensionapp.dark_theme
+        page_config['disabledExtensions'] = [
+            # Remove editor-related items from Settings menu
+            '@jupyterlab/fileeditor-extension',
+            # Remove items Open JupyterLab and File Browser from View menu
+            '@jupyter-notebook/application-extension:pages',
+            # Remove toolbar button Interface > Open With JupyterLab
+            '@jupyter-notebook/lab-extension:interface-switcher',
+            # Remove Launch Jupyter Notebook File Browser from Help menu
+            '@jupyter-notebook/lab-extension:launch-tree'
+        ]
         return page_config
 
     @web.authenticated


### PR DESCRIPTION
Specifically, this removes:
- menu item `View > Open JupyterLab`
- menu item `View > File Browser`
- menu item related to file editor in `Settings` menu
- menu item `Help > Launch Jupyter Notebook File Browser`
- toolbar button `Interface > Open With JupyterLab / Jupyter Notebook`

Fixes #400.