### PR TITLE
PR: Catch NotJSONError in wait_and_check_if_empty()

### DIFF
--- a/spyder_notebook/widgets/notebooktabwidget.py
+++ b/spyder_notebook/widgets/notebooktabwidget.py
@@ -348,7 +348,7 @@ class NotebookTabWidget(Tabs, SpyderConfigurationAccessor):
             # Try reading the file
             try:
                 nb_contents = nbformat.read(filename, as_version=4)
-            except FileNotFoundError:
+            except (FileNotFoundError, nbformat.reader.NotJSONError):
                 continue
 
             # If empty, we are done


### PR DESCRIPTION
This appears to be a rare error and its cause is not clear. The working assumption is that this exception may be raised if Spyder tries to read the notebook file before it is completely saved, so we wait a while and try again.

Fixes #432 