### PR TITLE
PR: Support Spyder 5 instead of Spyder 6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         OS: ['ubuntu', 'macos', 'windows']
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
-        SPYDER_SOURCE: ['git']
+        SPYDER_SOURCE: ['conda']
     name: ${{ matrix.OS }} py${{ matrix.PYTHON_VERSION }} spyder-from-${{ matrix.SPYDER_SOURCE }}
     runs-on: ${{ matrix.OS }}-latest
     env:

--- a/spyder_notebook/notebookplugin.py
+++ b/spyder_notebook/notebookplugin.py
@@ -13,7 +13,6 @@ import os.path as osp
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.plugin_registration.decorators import (
     on_plugin_available, on_plugin_teardown)
-from spyder.plugins.switcher.utils import shorten_paths
 
 # Local imports
 from spyder_notebook.config import CONF_DEFAULTS, CONF_VERSION
@@ -29,7 +28,7 @@ class NotebookPlugin(SpyderDockablePlugin):
 
     NAME = 'notebook'
     REQUIRES = [Plugins.Preferences]
-    OPTIONAL = [Plugins.IPythonConsole, Plugins.Switcher]
+    OPTIONAL = [Plugins.IPythonConsole]
     TABIFY = [Plugins.Editor]
     CONF_SECTION = NAME
     CONF_DEFAULTS = CONF_DEFAULTS
@@ -67,12 +66,6 @@ class NotebookPlugin(SpyderDockablePlugin):
         self.get_widget().sig_open_console_requested.connect(
             self._open_console)
 
-    @on_plugin_available(plugin=Plugins.Switcher)
-    def on_switcher_available(self):
-        switcher = self.get_plugin(Plugins.Switcher)
-        switcher.sig_mode_selected.connect(self._handle_switcher_modes)
-        switcher.sig_item_selected.connect(self._handle_switcher_selection)
-
     @on_plugin_teardown(plugin=Plugins.Preferences)
     def on_preferences_teardown(self):
         preferences = self.get_plugin(Plugins.Preferences)
@@ -82,12 +75,6 @@ class NotebookPlugin(SpyderDockablePlugin):
     def on_ipyconsole_teardown(self):
         self.get_widget().sig_open_console_requested.disconnect(
             self._open_console)
-
-    @on_plugin_teardown(plugin=Plugins.Switcher)
-    def on_switcher_teardown(self):
-        switcher = self.get_plugin(Plugins.Switcher)
-        switcher.sig_mode_selected.disconnect(self._handle_switcher_modes)
-        switcher.sig_item_selected.disconnect(self._handle_switcher_selection)
 
     def on_mainwindow_visible(self):
         self.get_widget().open_previous_session()
@@ -105,56 +92,3 @@ class NotebookPlugin(SpyderDockablePlugin):
         ipyclient = ipyconsole.get_current_client()
         ipyclient.allow_rename = False
         ipyconsole.rename_client_tab(ipyclient, tab_name)
-
-    def _handle_switcher_modes(self, mode):
-        """
-        Populate switcher with opened notebooks.
-
-        List the file names of the opened notebooks with their directories in
-        the switcher. Only handle file mode, where `mode` is empty string.
-        """
-        if mode != '':
-            return
-
-        tabwidget = self.get_widget().tabwidget
-        clients = [tabwidget.widget(i) for i in range(tabwidget.count())]
-        paths = [client.get_filename() for client in clients]
-        is_unsaved = [False for client in clients]
-        short_paths = shorten_paths(paths, is_unsaved)
-        icon = self.create_icon('notebook')
-        section = self.get_name()
-        switcher = self.get_plugin(Plugins.Switcher)
-
-        for path, short_path, client in zip(paths, short_paths, clients):
-            title = osp.basename(path)
-            description = osp.dirname(path)
-            if len(path) > 75:
-                description = short_path
-            is_last_item = (client == clients[-1])
-
-            switcher.add_item(
-                title=title,
-                description=description,
-                icon=icon,
-                section=section,
-                data=client,
-                last_item=is_last_item
-            )
-
-    def _handle_switcher_selection(self, item, mode, search_text):
-        """
-        Handle user selecting item in switcher.
-
-        If the selected item is not in the section of the switcher that
-        corresponds to this plugin, then ignore it. Otherwise, switch to
-        selected item in notebook plugin and hide the switcher.
-        """
-        if item.get_section() != self.get_name():
-            return
-
-        client = item.get_data()
-        tabwidget = self.get_widget().tabwidget
-        tabwidget.setCurrentIndex(tabwidget.indexOf(client))
-        self.switch_to_plugin()
-        switcher = self.get_plugin(Plugins.Switcher)
-        switcher.hide()

--- a/spyder_notebook/tests/test_plugin.py
+++ b/spyder_notebook/tests/test_plugin.py
@@ -73,6 +73,7 @@ def is_kernel_up(kernel_id, sessions_url):
 class MainMock(QMainWindow):
     def __init__(self):
         super().__init__()
+        self.switcher = Mock()
         self.main = self
         self.resize(640, 480)
 

--- a/spyder_notebook/widgets/main_widget.py
+++ b/spyder_notebook/widgets/main_widget.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import QMessageBox, QVBoxLayout
 # Spyder imports
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.gui import is_dark_interface
+from spyder.plugins.switcher.utils import shorten_paths
 
 # Local imports
 from spyder_notebook.utils.localization import _
@@ -84,6 +85,12 @@ class NotebookMainWidget(PluginMainWidget):
         layout = QVBoxLayout()
         layout.addWidget(self.tabwidget)
         self.setLayout(layout)
+
+        # Connect to switcher
+        self.switcher = plugin.main.switcher
+        self.switcher.sig_mode_selected.connect(self.handle_switcher_modes)
+        self.switcher.sig_item_selected.connect(
+            self.handle_switcher_selection)
 
     # ---- PluginMainWidget API
     # ------------------------------------------------------------------------
@@ -337,3 +344,54 @@ class NotebookMainWidget(PluginMainWidget):
         """Clear the list of recent notebooks."""
         self.recent_notebooks = []
         self.update_recent_notebooks_menu()
+
+    def handle_switcher_modes(self, mode):
+        """
+        Populate switcher with opened notebooks.
+
+        List the file names of the opened notebooks with their directories in
+        the switcher. Only handle file mode, where `mode` is empty string.
+        """
+        if mode != '':
+            return
+
+        clients = [self.tabwidget.widget(i)
+                   for i in range(self.tabwidget.count())]
+        paths = [client.get_filename() for client in clients]
+        is_unsaved = [False for client in clients]
+        short_paths = shorten_paths(paths, is_unsaved)
+        icon = self.create_icon('notebook')
+        section = self.get_title()
+
+        for path, short_path, client in zip(paths, short_paths, clients):
+            title = osp.basename(path)
+            description = osp.dirname(path)
+            if len(path) > 75:
+                description = short_path
+            is_last_item = (client == clients[-1])
+
+            self.switcher.add_item(
+                title=title,
+                description=description,
+                icon=icon,
+                section=section,
+                data=client,
+                last_item=is_last_item
+            )
+
+    def handle_switcher_selection(self, item, mode, search_text):
+        """
+        Handle user selecting item in switcher.
+
+        If the selected item is not in the section of the switcher that
+        corresponds to this plugin, then ignore it. Otherwise, switch to
+        selected item in notebook plugin and hide the switcher.
+        """
+        if item.get_section() != self.get_title():
+            return
+
+        client = item.get_data()
+        index = self.tabwidget.indexOf(client)
+        self.tabwidget.setCurrentIndex(index)
+        self._plugin.switch_to_plugin()
+        self.switcher.hide()

--- a/spyder_notebook/widgets/main_widget.py
+++ b/spyder_notebook/widgets/main_widget.py
@@ -15,7 +15,7 @@ from qtpy.QtWidgets import QMessageBox, QVBoxLayout
 # Spyder imports
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.config.gui import is_dark_interface
-from spyder.plugins.switcher.utils import shorten_paths
+from spyder.utils.switcher import shorten_paths
 
 # Local imports
 from spyder_notebook.utils.localization import _


### PR DESCRIPTION
The 0.5.x branch of the plugin should be compatible with Spyder 5. Thus, we partially revert PR #417.

Fixes #423.