### PR TITLE
PR: Check that Plugins config page works with notebook plugin

### DIFF
--- a/spyder_notebook/tests/test_config.py
+++ b/spyder_notebook/tests/test_config.py
@@ -13,6 +13,8 @@ import pytest
 from qtpy.QtWidgets import QMainWindow
 
 # Local imports
+from spyder.api.plugin_registration._confpage import PluginsConfigPage
+from spyder.api.plugin_registration.registry import PLUGIN_REGISTRY
 from spyder_notebook.notebookplugin import NotebookPlugin
 
 
@@ -30,6 +32,15 @@ class MainWindowMock(QMainWindow):
     [[MainWindowMock, [], [NotebookPlugin]]],
     indirect=True)
 def test_config_dialog(config_dialog):
+    # Check that Notebook config page works
     configpage = config_dialog.get_page()
     assert configpage
     configpage.save_to_conf()
+
+    # Check that Plugins config page works with notebook plugin
+    # Regression test for spyder-ide/spyder-notebook#470
+    PLUGIN_REGISTRY.set_all_internal_plugins(
+        {NotebookPlugin.NAME: (NotebookPlugin.NAME, NotebookPlugin)}
+    )
+    plugins_config_page = PluginsConfigPage(PLUGIN_REGISTRY, config_dialog)
+    plugins_config_page.initialize()


### PR DESCRIPTION
Extend the test in `test_config.py` to check that the Plugins config page work. This would have caught the error in #470.

Having to call `set_all_internal_plugins()` explicitly makes the test a bit brittle but I don't see a better way to do this.

Fixes #472.