### PR TITLE
Fix interrupting Spyder kernel

### DIFF
--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -3,6 +3,7 @@ jupyter_core
 jupyter_server
 nbformat
 notebook >=7.2,<8
+psutil
 qtpy
 qdarkstyle
 requests

--- a/setup.py
+++ b/setup.py
@@ -113,5 +113,9 @@ setup(
         "spyder.plugins": [
             "notebook = spyder_notebook.notebookplugin:NotebookPlugin"
         ],
+        "jupyter_client.kernel_provisioners": [
+            "spyder-local-provisioner ="
+            " spyder_notebook.server.main:SpyderLocalProvisioner"
+        ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ REQUIREMENTS = [
     'spyder>=6,<7',
     'nbformat',
     'notebook>=7.2,<8',
+    'psutil',
     'qtpy',
     'qdarkstyle',
     'requests',

--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -4,8 +4,11 @@
 """Entry point for server rendering notebooks for Spyder."""
 
 import os
+from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_server.serverapp import ServerApp
 from notebook.app import (
     aliases, flags, JupyterNotebookApp, NotebookBaseHandler)
+from spyder.plugins.ipythonconsole.utils.kernelspec import SpyderKernelSpec
 from tornado import web
 from traitlets import default, Bool, Unicode
 
@@ -45,11 +48,29 @@ class SpyderNotebookHandler(NotebookBaseHandler):
         return self.write(tpl)
 
 
+class SpyderKernelSpecManager(KernelSpecManager):
+    """Variant of Jupyter's KernelSpecManager"""
+    kernel_spec_class = SpyderKernelSpec
+
+
+class SpyderServerApp(ServerApp):
+    """Variant of Jupyter's ServerApp"""
+    kernel_spec_manager_class = SpyderKernelSpecManager
+
+
 class SpyderNotebookApp(JupyterNotebookApp):
     """The Spyder notebook server extension app."""
 
     name = 'spyder_notebook'
+    app_name = "Spyder/Jupyter Notebook"
+    description = "Spyder/Jupyter Notebook - A variant of Jupyter Notebook to be used inside Spyder"
     file_url_prefix = "/spyder-notebooks"
+
+    # Replace Jupyter's ServerApp with our own
+    serverapp_class = SpyderServerApp
+
+    # Do not open web browser when starting app
+    open_browser = False
 
     flags = dict(flags)
     aliases = dict(aliases)
@@ -57,8 +78,6 @@ class SpyderNotebookApp(JupyterNotebookApp):
     dark_theme = Bool(
         False, config=True,
         help='Whether to use dark theme when rendering notebooks')
-
-    flags = flags
 
     info_file_cmdline = Unicode(
         '', config=True,

--- a/spyder_notebook/utils/servermanager.py
+++ b/spyder_notebook/utils/servermanager.py
@@ -27,9 +27,6 @@ from tornado.httpclient import HTTPClientError
 from spyder.config.base import DEV, get_home_dir, get_module_path
 
 
-# Kernel specification to use in notebook server
-KERNELSPEC = 'spyder.plugins.ipythonconsole.utils.kernelspec.SpyderKernelSpec'
-
 # Delay we wait to check whether server is up (in ms)
 CHECK_SERVER_UP_DELAY = 250
 
@@ -211,11 +208,9 @@ class ServerManager(QObject):
         my_pid = os.getpid()
         server_index = len(self.servers) + 1
         info_file = f'spynbserver-{my_pid}-{server_index}.json'
-        arguments = ['-m', 'spyder_notebook.server', '--no-browser',
+        arguments = ['-m', 'spyder_notebook.server',
                      f'--info-file={info_file}',
-                     f'--notebook-dir={nbdir}',
-                     '--ServerApp.password=',
-                     f'--KernelSpecManager.kernel_spec_class={KERNELSPEC}']
+                     f'--notebook-dir={nbdir}']
         if self.dark_theme:
             arguments.append('--dark')
 


### PR DESCRIPTION
Interrupting a kernel is done on Unix by sending SIGINT to the Python process. However, Spyder kernels use `conda run` to run the kernel in the correct environment. The SIGINT signal should not be sent to the `conda run` process, because that causes it to quit. Instead, find the Python process started by `conda run`, because it will handle SIGINT correctly by raising a KeyboardInterrupt.

This PR does some further clean up in the code for the notebook server because I now understand how to specify default configuration values instead of passing them on the command line.

Fixes #478 