### PR TITLE
Ensure that only one kernel spec is available

### DIFF
--- a/spyder_notebook/server/main.py
+++ b/spyder_notebook/server/main.py
@@ -103,6 +103,10 @@ class SpyderNotebookKernelSpec(SpyderKernelSpec):
 
 class SpyderKernelSpecManager(KernelSpecManager):
     """Variant of Jupyter's KernelSpecManager"""
+    # Ensure that there is only one kernel spec, the default one
+    allowed_kernelspecs = 'python3'
+
+    # Ensure that default kernel spec is our own kernel spec
     kernel_spec_class = SpyderNotebookKernelSpec
 
 


### PR DESCRIPTION
If the user has installed other kernel specs, for instance for IPython kernels in other environments, and then changes kernel then all the kernel specs are shown with the same text (the display name of our own kernel spec). This is confusing.

This commit ensures that only one kernel spec is shown.

Fixes #475